### PR TITLE
feat(danfe): ajustes Revenda Mais (CST/CSOSN + Forma de Pagamento + Marca Cancelada)

### DIFF
--- a/.claude/commands/opsx/apply.md
+++ b/.claude/commands/opsx/apply.md
@@ -1,0 +1,152 @@
+---
+name: "OPSX: Apply"
+description: Implement tasks from an OpenSpec change (Experimental)
+category: Workflow
+tags: [workflow, artifacts, experimental]
+---
+
+Implement tasks from an OpenSpec change.
+
+**Input**: Optionally specify a change name (e.g., `/opsx:apply add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **Select the change**
+
+   If a name is provided, use it. Otherwise:
+   - Infer from conversation context if the user mentioned a change
+   - Auto-select if only one active change exists
+   - If ambiguous, run `openspec list --json` to get available changes and use the **AskUserQuestion tool** to let the user select
+
+   Always announce: "Using change: <name>" and how to override (e.g., `/opsx:apply <other>`).
+
+2. **Check status to understand the schema**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used (e.g., "spec-driven")
+   - Which artifact contains the tasks (typically "tasks" for spec-driven, check status for others)
+
+3. **Get apply instructions**
+
+   ```bash
+   openspec instructions apply --change "<name>" --json
+   ```
+
+   This returns:
+   - `contextFiles`: artifact ID -> array of concrete file paths (varies by schema)
+   - Progress (total, complete, remaining)
+   - Task list with status
+   - Dynamic instruction based on current state
+
+   **Handle states:**
+   - If `state: "blocked"` (missing artifacts): show message, suggest using `/opsx:continue`
+   - If `state: "all_done"`: congratulate, suggest archive
+   - Otherwise: proceed to implementation
+
+4. **Read context files**
+
+   Read every file path listed under `contextFiles` from the apply instructions output.
+   The files depend on the schema being used:
+   - **spec-driven**: proposal, specs, design, tasks
+   - Other schemas: follow the contextFiles from CLI output
+
+5. **Show current progress**
+
+   Display:
+   - Schema being used
+   - Progress: "N/M tasks complete"
+   - Remaining tasks overview
+   - Dynamic instruction from CLI
+
+6. **Implement tasks (loop until done or blocked)**
+
+   For each pending task:
+   - Show which task is being worked on
+   - Make the code changes required
+   - Keep changes minimal and focused
+   - Mark task complete in the tasks file: `- [ ]` → `- [x]`
+   - Continue to next task
+
+   **Pause if:**
+   - Task is unclear → ask for clarification
+   - Implementation reveals a design issue → suggest updating artifacts
+   - Error or blocker encountered → report and wait for guidance
+   - User interrupts
+
+7. **On completion or pause, show status**
+
+   Display:
+   - Tasks completed this session
+   - Overall progress: "N/M tasks complete"
+   - If all done: suggest archive
+   - If paused: explain why and wait for guidance
+
+**Output During Implementation**
+
+```
+## Implementing: <change-name> (schema: <schema-name>)
+
+Working on task 3/7: <task description>
+[...implementation happening...]
+✓ Task complete
+
+Working on task 4/7: <task description>
+[...implementation happening...]
+✓ Task complete
+```
+
+**Output On Completion**
+
+```
+## Implementation Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 7/7 tasks complete ✓
+
+### Completed This Session
+- [x] Task 1
+- [x] Task 2
+...
+
+All tasks complete! You can archive this change with `/opsx:archive`.
+```
+
+**Output On Pause (Issue Encountered)**
+
+```
+## Implementation Paused
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 4/7 tasks complete
+
+### Issue Encountered
+<description of the issue>
+
+**Options:**
+1. <option 1>
+2. <option 2>
+3. Other approach
+
+What would you like to do?
+```
+
+**Guardrails**
+- Keep going through tasks until done or blocked
+- Always read context files before starting (from the apply instructions output)
+- If task is ambiguous, pause and ask before implementing
+- If implementation reveals issues, pause and suggest artifact updates
+- Keep code changes minimal and scoped to each task
+- Update task checkbox immediately after completing each task
+- Pause on errors, blockers, or unclear requirements - don't guess
+- Use contextFiles from CLI output, don't assume specific file names
+
+**Fluid Workflow Integration**
+
+This skill supports the "actions on a change" model:
+
+- **Can be invoked anytime**: Before all artifacts are done (if tasks exist), after partial implementation, interleaved with other actions
+- **Allows artifact updates**: If implementation reveals design issues, suggest updating artifacts - not phase-locked, work fluidly

--- a/.claude/commands/opsx/archive.md
+++ b/.claude/commands/opsx/archive.md
@@ -1,0 +1,157 @@
+---
+name: "OPSX: Archive"
+description: Archive a completed change in the experimental workflow
+category: Workflow
+tags: [workflow, archive, experimental]
+---
+
+Archive a completed change in the experimental workflow.
+
+**Input**: Optionally specify a change name after `/opsx:archive` (e.g., `/opsx:archive add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show only active changes (not already archived).
+   Include the schema used for each change if available.
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Check artifact completion status**
+
+   Run `openspec status --change "<name>" --json` to check artifact completion.
+
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used
+   - `artifacts`: List of artifacts with their status (`done` or other)
+
+   **If any artifacts are not `done`:**
+   - Display warning listing incomplete artifacts
+   - Prompt user for confirmation to continue
+   - Proceed if user confirms
+
+3. **Check task completion status**
+
+   Read the tasks file (typically `tasks.md`) to check for incomplete tasks.
+
+   Count tasks marked with `- [ ]` (incomplete) vs `- [x]` (complete).
+
+   **If incomplete tasks found:**
+   - Display warning showing count of incomplete tasks
+   - Prompt user for confirmation to continue
+   - Proceed if user confirms
+
+   **If no tasks file exists:** Proceed without task-related warning.
+
+4. **Assess delta spec sync state**
+
+   Check for delta specs at `openspec/changes/<name>/specs/`. If none exist, proceed without sync prompt.
+
+   **If delta specs exist:**
+   - Compare each delta spec with its corresponding main spec at `openspec/specs/<capability>/spec.md`
+   - Determine what changes would be applied (adds, modifications, removals, renames)
+   - Show a combined summary before prompting
+
+   **Prompt options:**
+   - If changes needed: "Sync now (recommended)", "Archive without syncing"
+   - If already synced: "Archive now", "Sync anyway", "Cancel"
+
+   If user chooses sync, use Task tool (subagent_type: "general-purpose", prompt: "Use Skill tool to invoke openspec-sync-specs for change '<name>'. Delta spec analysis: <include the analyzed delta spec summary>"). Proceed to archive regardless of choice.
+
+5. **Perform the archive**
+
+   Create the archive directory if it doesn't exist:
+   ```bash
+   mkdir -p openspec/changes/archive
+   ```
+
+   Generate target name using current date: `YYYY-MM-DD-<change-name>`
+
+   **Check if target already exists:**
+   - If yes: Fail with error, suggest renaming existing archive or using different date
+   - If no: Move the change directory to archive
+
+   ```bash
+   mv openspec/changes/<name> openspec/changes/archive/YYYY-MM-DD-<name>
+   ```
+
+6. **Display summary**
+
+   Show archive completion summary including:
+   - Change name
+   - Schema that was used
+   - Archive location
+   - Spec sync status (synced / sync skipped / no delta specs)
+   - Note about any warnings (incomplete artifacts/tasks)
+
+**Output On Success**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** ✓ Synced to main specs
+
+All artifacts complete. All tasks complete.
+```
+
+**Output On Success (No Delta Specs)**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** No delta specs
+
+All artifacts complete. All tasks complete.
+```
+
+**Output On Success With Warnings**
+
+```
+## Archive Complete (with warnings)
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** Sync skipped (user chose to skip)
+
+**Warnings:**
+- Archived with 2 incomplete artifacts
+- Archived with 3 incomplete tasks
+- Delta spec sync was skipped (user chose to skip)
+
+Review the archive if this was not intentional.
+```
+
+**Output On Error (Archive Exists)**
+
+```
+## Archive Failed
+
+**Change:** <change-name>
+**Target:** openspec/changes/archive/YYYY-MM-DD-<name>/
+
+Target archive directory already exists.
+
+**Options:**
+1. Rename the existing archive
+2. Delete the existing archive if it's a duplicate
+3. Wait until a different date to archive
+```
+
+**Guardrails**
+- Always prompt for change selection if not provided
+- Use artifact graph (openspec status --json) for completion checking
+- Don't block archive on warnings - just inform and confirm
+- Preserve .openspec.yaml when moving to archive (it moves with the directory)
+- Show clear summary of what happened
+- If sync is requested, use the Skill tool to invoke `openspec-sync-specs` (agent-driven)
+- If delta specs exist, always run the sync assessment and show the combined summary before prompting

--- a/.claude/commands/opsx/explore.md
+++ b/.claude/commands/opsx/explore.md
@@ -1,0 +1,173 @@
+---
+name: "OPSX: Explore"
+description: "Enter explore mode - think through ideas, investigate problems, clarify requirements"
+category: Workflow
+tags: [workflow, explore, experimental, thinking]
+---
+
+Enter explore mode. Think deeply. Visualize freely. Follow the conversation wherever it goes.
+
+**IMPORTANT: Explore mode is for thinking, not implementing.** You may read files, search code, and investigate the codebase, but you must NEVER write code or implement features. If the user asks you to implement something, remind them to exit explore mode first and create a change proposal. You MAY create OpenSpec artifacts (proposals, designs, specs) if the user asks—that's capturing thinking, not implementing.
+
+**This is a stance, not a workflow.** There are no fixed steps, no required sequence, no mandatory outputs. You're a thinking partner helping the user explore.
+
+**Input**: The argument after `/opsx:explore` is whatever the user wants to think about. Could be:
+- A vague idea: "real-time collaboration"
+- A specific problem: "the auth system is getting unwieldy"
+- A change name: "add-dark-mode" (to explore in context of that change)
+- A comparison: "postgres vs sqlite for this"
+- Nothing (just enter explore mode)
+
+---
+
+## The Stance
+
+- **Curious, not prescriptive** - Ask questions that emerge naturally, don't follow a script
+- **Open threads, not interrogations** - Surface multiple interesting directions and let the user follow what resonates. Don't funnel them through a single path of questions.
+- **Visual** - Use ASCII diagrams liberally when they'd help clarify thinking
+- **Adaptive** - Follow interesting threads, pivot when new information emerges
+- **Patient** - Don't rush to conclusions, let the shape of the problem emerge
+- **Grounded** - Explore the actual codebase when relevant, don't just theorize
+
+---
+
+## What You Might Do
+
+Depending on what the user brings, you might:
+
+**Explore the problem space**
+- Ask clarifying questions that emerge from what they said
+- Challenge assumptions
+- Reframe the problem
+- Find analogies
+
+**Investigate the codebase**
+- Map existing architecture relevant to the discussion
+- Find integration points
+- Identify patterns already in use
+- Surface hidden complexity
+
+**Compare options**
+- Brainstorm multiple approaches
+- Build comparison tables
+- Sketch tradeoffs
+- Recommend a path (if asked)
+
+**Visualize**
+```
+┌─────────────────────────────────────────┐
+│     Use ASCII diagrams liberally        │
+├─────────────────────────────────────────┤
+│                                         │
+│      ┌────────┐         ┌────────┐      │
+│      │ State  │────────▶│ State  │      │
+│      │   A    │         │   B    │      │
+│      └────────┘         └────────┘      │
+│                                         │
+│   System diagrams, state machines,      │
+│   data flows, architecture sketches,    │
+│   dependency graphs, comparison tables  │
+│                                         │
+└─────────────────────────────────────────┘
+```
+
+**Surface risks and unknowns**
+- Identify what could go wrong
+- Find gaps in understanding
+- Suggest spikes or investigations
+
+---
+
+## OpenSpec Awareness
+
+You have full context of the OpenSpec system. Use it naturally, don't force it.
+
+### Check for context
+
+At the start, quickly check what exists:
+```bash
+openspec list --json
+```
+
+This tells you:
+- If there are active changes
+- Their names, schemas, and status
+- What the user might be working on
+
+If the user mentioned a specific change name, read its artifacts for context.
+
+### When no change exists
+
+Think freely. When insights crystallize, you might offer:
+
+- "This feels solid enough to start a change. Want me to create a proposal?"
+- Or keep exploring - no pressure to formalize
+
+### When a change exists
+
+If the user mentions a change or you detect one is relevant:
+
+1. **Read existing artifacts for context**
+   - `openspec/changes/<name>/proposal.md`
+   - `openspec/changes/<name>/design.md`
+   - `openspec/changes/<name>/tasks.md`
+   - etc.
+
+2. **Reference them naturally in conversation**
+   - "Your design mentions using Redis, but we just realized SQLite fits better..."
+   - "The proposal scopes this to premium users, but we're now thinking everyone..."
+
+3. **Offer to capture when decisions are made**
+
+    | Insight Type               | Where to Capture               |
+    |----------------------------|--------------------------------|
+    | New requirement discovered | `specs/<capability>/spec.md` |
+    | Requirement changed        | `specs/<capability>/spec.md` |
+    | Design decision made       | `design.md`                  |
+    | Scope changed              | `proposal.md`                |
+    | New work identified        | `tasks.md`                   |
+    | Assumption invalidated     | Relevant artifact              |
+
+   Example offers:
+   - "That's a design decision. Capture it in design.md?"
+   - "This is a new requirement. Add it to specs?"
+   - "This changes scope. Update the proposal?"
+
+4. **The user decides** - Offer and move on. Don't pressure. Don't auto-capture.
+
+---
+
+## What You Don't Have To Do
+
+- Follow a script
+- Ask the same questions every time
+- Produce a specific artifact
+- Reach a conclusion
+- Stay on topic if a tangent is valuable
+- Be brief (this is thinking time)
+
+---
+
+## Ending Discovery
+
+There's no required ending. Discovery might:
+
+- **Flow into a proposal**: "Ready to start? I can create a change proposal."
+- **Result in artifact updates**: "Updated design.md with these decisions"
+- **Just provide clarity**: User has what they need, moves on
+- **Continue later**: "We can pick this up anytime"
+
+When things crystallize, you might offer a summary - but it's optional. Sometimes the thinking IS the value.
+
+---
+
+## Guardrails
+
+- **Don't implement** - Never write code or implement features. Creating OpenSpec artifacts is fine, writing application code is not.
+- **Don't fake understanding** - If something is unclear, dig deeper
+- **Don't rush** - Discovery is thinking time, not task time
+- **Don't force structure** - Let patterns emerge naturally
+- **Don't auto-capture** - Offer to save insights, don't just do it
+- **Do visualize** - A good diagram is worth many paragraphs
+- **Do explore the codebase** - Ground discussions in reality
+- **Do question assumptions** - Including the user's and your own

--- a/.claude/commands/opsx/propose.md
+++ b/.claude/commands/opsx/propose.md
@@ -1,0 +1,106 @@
+---
+name: "OPSX: Propose"
+description: Propose a new change - create it and generate all artifacts in one step
+category: Workflow
+tags: [workflow, artifacts, experimental]
+---
+
+Propose a new change - create the change and generate all artifacts in one step.
+
+I'll create a change with artifacts:
+- proposal.md (what & why)
+- design.md (how)
+- tasks.md (implementation steps)
+
+When ready to implement, run /opsx:apply
+
+---
+
+**Input**: The argument after `/opsx:propose` is the change name (kebab-case), OR a description of what the user wants to build.
+
+**Steps**
+
+1. **If no input provided, ask what they want to build**
+
+   Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
+   > "What change do you want to work on? Describe what you want to build or fix."
+
+   From their description, derive a kebab-case name (e.g., "add user authentication" → `add-user-auth`).
+
+   **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
+
+2. **Create the change directory**
+   ```bash
+   openspec new change "<name>"
+   ```
+   This creates a scaffolded change at `openspec/changes/<name>/` with `.openspec.yaml`.
+
+3. **Get the artifact build order**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to get:
+   - `applyRequires`: array of artifact IDs needed before implementation (e.g., `["tasks"]`)
+   - `artifacts`: list of all artifacts with their status and dependencies
+
+4. **Create artifacts in sequence until apply-ready**
+
+   Use the **TodoWrite tool** to track progress through the artifacts.
+
+   Loop through artifacts in dependency order (artifacts with no pending dependencies first):
+
+   a. **For each artifact that is `ready` (dependencies satisfied)**:
+      - Get instructions:
+        ```bash
+        openspec instructions <artifact-id> --change "<name>" --json
+        ```
+      - The instructions JSON includes:
+        - `context`: Project background (constraints for you - do NOT include in output)
+        - `rules`: Artifact-specific rules (constraints for you - do NOT include in output)
+        - `template`: The structure to use for your output file
+        - `instruction`: Schema-specific guidance for this artifact type
+        - `outputPath`: Where to write the artifact
+        - `dependencies`: Completed artifacts to read for context
+      - Read any completed dependency files for context
+      - Create the artifact file using `template` as the structure
+      - Apply `context` and `rules` as constraints - but do NOT copy them into the file
+      - Show brief progress: "Created <artifact-id>"
+
+   b. **Continue until all `applyRequires` artifacts are complete**
+      - After creating each artifact, re-run `openspec status --change "<name>" --json`
+      - Check if every artifact ID in `applyRequires` has `status: "done"` in the artifacts array
+      - Stop when all `applyRequires` artifacts are done
+
+   c. **If an artifact requires user input** (unclear context):
+      - Use **AskUserQuestion tool** to clarify
+      - Then continue with creation
+
+5. **Show final status**
+   ```bash
+   openspec status --change "<name>"
+   ```
+
+**Output**
+
+After completing all artifacts, summarize:
+- Change name and location
+- List of artifacts created with brief descriptions
+- What's ready: "All artifacts created! Ready for implementation."
+- Prompt: "Run `/opsx:apply` to start implementing."
+
+**Artifact Creation Guidelines**
+
+- Follow the `instruction` field from `openspec instructions` for each artifact type
+- The schema defines what each artifact should contain - follow it
+- Read dependency artifacts for context before creating new ones
+- Use `template` as the structure for your output file - fill in its sections
+- **IMPORTANT**: `context` and `rules` are constraints for YOU, not content for the file
+  - Do NOT copy `<context>`, `<rules>`, `<project_context>` blocks into the artifact
+  - These guide what you write, but should never appear in the output
+
+**Guardrails**
+- Create ALL artifacts needed for implementation (as defined by schema's `apply.requires`)
+- Always read dependency artifacts before creating a new one
+- If context is critically unclear, ask the user - but prefer making reasonable decisions to keep momentum
+- If a change with that name already exists, ask if user wants to continue it or create a new one
+- Verify each artifact file exists after writing before proceeding to next

--- a/.claude/skills/openspec-apply-change/SKILL.md
+++ b/.claude/skills/openspec-apply-change/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: openspec-apply-change
+description: Implement tasks from an OpenSpec change. Use when the user wants to start implementing, continue implementation, or work through tasks.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.3.1"
+---
+
+Implement tasks from an OpenSpec change.
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **Select the change**
+
+   If a name is provided, use it. Otherwise:
+   - Infer from conversation context if the user mentioned a change
+   - Auto-select if only one active change exists
+   - If ambiguous, run `openspec list --json` to get available changes and use the **AskUserQuestion tool** to let the user select
+
+   Always announce: "Using change: <name>" and how to override (e.g., `/opsx:apply <other>`).
+
+2. **Check status to understand the schema**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used (e.g., "spec-driven")
+   - Which artifact contains the tasks (typically "tasks" for spec-driven, check status for others)
+
+3. **Get apply instructions**
+
+   ```bash
+   openspec instructions apply --change "<name>" --json
+   ```
+
+   This returns:
+   - `contextFiles`: artifact ID -> array of concrete file paths (varies by schema - could be proposal/specs/design/tasks or spec/tests/implementation/docs)
+   - Progress (total, complete, remaining)
+   - Task list with status
+   - Dynamic instruction based on current state
+
+   **Handle states:**
+   - If `state: "blocked"` (missing artifacts): show message, suggest using openspec-continue-change
+   - If `state: "all_done"`: congratulate, suggest archive
+   - Otherwise: proceed to implementation
+
+4. **Read context files**
+
+   Read every file path listed under `contextFiles` from the apply instructions output.
+   The files depend on the schema being used:
+   - **spec-driven**: proposal, specs, design, tasks
+   - Other schemas: follow the contextFiles from CLI output
+
+5. **Show current progress**
+
+   Display:
+   - Schema being used
+   - Progress: "N/M tasks complete"
+   - Remaining tasks overview
+   - Dynamic instruction from CLI
+
+6. **Implement tasks (loop until done or blocked)**
+
+   For each pending task:
+   - Show which task is being worked on
+   - Make the code changes required
+   - Keep changes minimal and focused
+   - Mark task complete in the tasks file: `- [ ]` → `- [x]`
+   - Continue to next task
+
+   **Pause if:**
+   - Task is unclear → ask for clarification
+   - Implementation reveals a design issue → suggest updating artifacts
+   - Error or blocker encountered → report and wait for guidance
+   - User interrupts
+
+7. **On completion or pause, show status**
+
+   Display:
+   - Tasks completed this session
+   - Overall progress: "N/M tasks complete"
+   - If all done: suggest archive
+   - If paused: explain why and wait for guidance
+
+**Output During Implementation**
+
+```
+## Implementing: <change-name> (schema: <schema-name>)
+
+Working on task 3/7: <task description>
+[...implementation happening...]
+✓ Task complete
+
+Working on task 4/7: <task description>
+[...implementation happening...]
+✓ Task complete
+```
+
+**Output On Completion**
+
+```
+## Implementation Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 7/7 tasks complete ✓
+
+### Completed This Session
+- [x] Task 1
+- [x] Task 2
+...
+
+All tasks complete! Ready to archive this change.
+```
+
+**Output On Pause (Issue Encountered)**
+
+```
+## Implementation Paused
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 4/7 tasks complete
+
+### Issue Encountered
+<description of the issue>
+
+**Options:**
+1. <option 1>
+2. <option 2>
+3. Other approach
+
+What would you like to do?
+```
+
+**Guardrails**
+- Keep going through tasks until done or blocked
+- Always read context files before starting (from the apply instructions output)
+- If task is ambiguous, pause and ask before implementing
+- If implementation reveals issues, pause and suggest artifact updates
+- Keep code changes minimal and scoped to each task
+- Update task checkbox immediately after completing each task
+- Pause on errors, blockers, or unclear requirements - don't guess
+- Use contextFiles from CLI output, don't assume specific file names
+
+**Fluid Workflow Integration**
+
+This skill supports the "actions on a change" model:
+
+- **Can be invoked anytime**: Before all artifacts are done (if tasks exist), after partial implementation, interleaved with other actions
+- **Allows artifact updates**: If implementation reveals design issues, suggest updating artifacts - not phase-locked, work fluidly

--- a/.claude/skills/openspec-archive-change/SKILL.md
+++ b/.claude/skills/openspec-archive-change/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: openspec-archive-change
+description: Archive a completed change in the experimental workflow. Use when the user wants to finalize and archive a change after implementation is complete.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.3.1"
+---
+
+Archive a completed change in the experimental workflow.
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show only active changes (not already archived).
+   Include the schema used for each change if available.
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Check artifact completion status**
+
+   Run `openspec status --change "<name>" --json` to check artifact completion.
+
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used
+   - `artifacts`: List of artifacts with their status (`done` or other)
+
+   **If any artifacts are not `done`:**
+   - Display warning listing incomplete artifacts
+   - Use **AskUserQuestion tool** to confirm user wants to proceed
+   - Proceed if user confirms
+
+3. **Check task completion status**
+
+   Read the tasks file (typically `tasks.md`) to check for incomplete tasks.
+
+   Count tasks marked with `- [ ]` (incomplete) vs `- [x]` (complete).
+
+   **If incomplete tasks found:**
+   - Display warning showing count of incomplete tasks
+   - Use **AskUserQuestion tool** to confirm user wants to proceed
+   - Proceed if user confirms
+
+   **If no tasks file exists:** Proceed without task-related warning.
+
+4. **Assess delta spec sync state**
+
+   Check for delta specs at `openspec/changes/<name>/specs/`. If none exist, proceed without sync prompt.
+
+   **If delta specs exist:**
+   - Compare each delta spec with its corresponding main spec at `openspec/specs/<capability>/spec.md`
+   - Determine what changes would be applied (adds, modifications, removals, renames)
+   - Show a combined summary before prompting
+
+   **Prompt options:**
+   - If changes needed: "Sync now (recommended)", "Archive without syncing"
+   - If already synced: "Archive now", "Sync anyway", "Cancel"
+
+   If user chooses sync, use Task tool (subagent_type: "general-purpose", prompt: "Use Skill tool to invoke openspec-sync-specs for change '<name>'. Delta spec analysis: <include the analyzed delta spec summary>"). Proceed to archive regardless of choice.
+
+5. **Perform the archive**
+
+   Create the archive directory if it doesn't exist:
+   ```bash
+   mkdir -p openspec/changes/archive
+   ```
+
+   Generate target name using current date: `YYYY-MM-DD-<change-name>`
+
+   **Check if target already exists:**
+   - If yes: Fail with error, suggest renaming existing archive or using different date
+   - If no: Move the change directory to archive
+
+   ```bash
+   mv openspec/changes/<name> openspec/changes/archive/YYYY-MM-DD-<name>
+   ```
+
+6. **Display summary**
+
+   Show archive completion summary including:
+   - Change name
+   - Schema that was used
+   - Archive location
+   - Whether specs were synced (if applicable)
+   - Note about any warnings (incomplete artifacts/tasks)
+
+**Output On Success**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** ✓ Synced to main specs (or "No delta specs" or "Sync skipped")
+
+All artifacts complete. All tasks complete.
+```
+
+**Guardrails**
+- Always prompt for change selection if not provided
+- Use artifact graph (openspec status --json) for completion checking
+- Don't block archive on warnings - just inform and confirm
+- Preserve .openspec.yaml when moving to archive (it moves with the directory)
+- Show clear summary of what happened
+- If sync is requested, use openspec-sync-specs approach (agent-driven)
+- If delta specs exist, always run the sync assessment and show the combined summary before prompting

--- a/.claude/skills/openspec-explore/SKILL.md
+++ b/.claude/skills/openspec-explore/SKILL.md
@@ -1,0 +1,288 @@
+---
+name: openspec-explore
+description: Enter explore mode - a thinking partner for exploring ideas, investigating problems, and clarifying requirements. Use when the user wants to think through something before or during a change.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.3.1"
+---
+
+Enter explore mode. Think deeply. Visualize freely. Follow the conversation wherever it goes.
+
+**IMPORTANT: Explore mode is for thinking, not implementing.** You may read files, search code, and investigate the codebase, but you must NEVER write code or implement features. If the user asks you to implement something, remind them to exit explore mode first and create a change proposal. You MAY create OpenSpec artifacts (proposals, designs, specs) if the user asks—that's capturing thinking, not implementing.
+
+**This is a stance, not a workflow.** There are no fixed steps, no required sequence, no mandatory outputs. You're a thinking partner helping the user explore.
+
+---
+
+## The Stance
+
+- **Curious, not prescriptive** - Ask questions that emerge naturally, don't follow a script
+- **Open threads, not interrogations** - Surface multiple interesting directions and let the user follow what resonates. Don't funnel them through a single path of questions.
+- **Visual** - Use ASCII diagrams liberally when they'd help clarify thinking
+- **Adaptive** - Follow interesting threads, pivot when new information emerges
+- **Patient** - Don't rush to conclusions, let the shape of the problem emerge
+- **Grounded** - Explore the actual codebase when relevant, don't just theorize
+
+---
+
+## What You Might Do
+
+Depending on what the user brings, you might:
+
+**Explore the problem space**
+- Ask clarifying questions that emerge from what they said
+- Challenge assumptions
+- Reframe the problem
+- Find analogies
+
+**Investigate the codebase**
+- Map existing architecture relevant to the discussion
+- Find integration points
+- Identify patterns already in use
+- Surface hidden complexity
+
+**Compare options**
+- Brainstorm multiple approaches
+- Build comparison tables
+- Sketch tradeoffs
+- Recommend a path (if asked)
+
+**Visualize**
+```
+┌─────────────────────────────────────────┐
+│     Use ASCII diagrams liberally        │
+├─────────────────────────────────────────┤
+│                                         │
+│      ┌────────┐         ┌────────┐      │
+│      │ State  │────────▶│ State  │      │
+│      │   A    │         │   B    │      │
+│      └────────┘         └────────┘      │
+│                                         │
+│   System diagrams, state machines,      │
+│   data flows, architecture sketches,    │
+│   dependency graphs, comparison tables  │
+│                                         │
+└─────────────────────────────────────────┘
+```
+
+**Surface risks and unknowns**
+- Identify what could go wrong
+- Find gaps in understanding
+- Suggest spikes or investigations
+
+---
+
+## OpenSpec Awareness
+
+You have full context of the OpenSpec system. Use it naturally, don't force it.
+
+### Check for context
+
+At the start, quickly check what exists:
+```bash
+openspec list --json
+```
+
+This tells you:
+- If there are active changes
+- Their names, schemas, and status
+- What the user might be working on
+
+### When no change exists
+
+Think freely. When insights crystallize, you might offer:
+
+- "This feels solid enough to start a change. Want me to create a proposal?"
+- Or keep exploring - no pressure to formalize
+
+### When a change exists
+
+If the user mentions a change or you detect one is relevant:
+
+1. **Read existing artifacts for context**
+   - `openspec/changes/<name>/proposal.md`
+   - `openspec/changes/<name>/design.md`
+   - `openspec/changes/<name>/tasks.md`
+   - etc.
+
+2. **Reference them naturally in conversation**
+   - "Your design mentions using Redis, but we just realized SQLite fits better..."
+   - "The proposal scopes this to premium users, but we're now thinking everyone..."
+
+3. **Offer to capture when decisions are made**
+
+    | Insight Type               | Where to Capture               |
+    |----------------------------|--------------------------------|
+    | New requirement discovered | `specs/<capability>/spec.md` |
+    | Requirement changed        | `specs/<capability>/spec.md` |
+    | Design decision made       | `design.md`                  |
+    | Scope changed              | `proposal.md`                |
+    | New work identified        | `tasks.md`                   |
+    | Assumption invalidated     | Relevant artifact              |
+
+   Example offers:
+   - "That's a design decision. Capture it in design.md?"
+   - "This is a new requirement. Add it to specs?"
+   - "This changes scope. Update the proposal?"
+
+4. **The user decides** - Offer and move on. Don't pressure. Don't auto-capture.
+
+---
+
+## What You Don't Have To Do
+
+- Follow a script
+- Ask the same questions every time
+- Produce a specific artifact
+- Reach a conclusion
+- Stay on topic if a tangent is valuable
+- Be brief (this is thinking time)
+
+---
+
+## Handling Different Entry Points
+
+**User brings a vague idea:**
+```
+User: I'm thinking about adding real-time collaboration
+
+You: Real-time collab is a big space. Let me think about this...
+
+      COLLABORATION SPECTRUM
+      ════════════════════════════════════════════
+
+      Awareness          Coordination         Sync
+          │                   │                 │
+          ▼                   ▼                 ▼
+      ┌────────┐         ┌────────┐        ┌────────┐
+      │Presence│         │Cursors │        │  CRDT  │
+      │  "3    │         │ Multi  │        │Conflict│
+      │online" │         │ select │        │  free  │
+      └────────┘         └────────┘        └────────┘
+          │                   │                 │
+       trivial            moderate           complex
+
+      Where's your head at?
+```
+
+**User brings a specific problem:**
+```
+User: The auth system is a mess
+
+You: [reads codebase]
+
+     ┌─────────────────────────────────────────────┐
+     │              CURRENT AUTH FLOW              │
+     └─────────────────────────────────────────────┘
+                        │
+          ┌─────────────┼─────────────┐
+          ▼             ▼             ▼
+     ┌─────────┐  ┌─────────┐  ┌─────────┐
+     │ Google  │  │  GitHub │  │  Email  │
+     │  OAuth  │  │  OAuth  │  │  Magic  │
+     └────┬────┘  └────┬────┘  └────┬────┘
+          │             │             │
+          └─────────────┼─────────────┘
+                        ▼
+                  ┌───────────┐
+                  │  Session  │
+                  └─────┬─────┘
+                        │
+                        ▼
+                  ┌───────────┐
+                  │   Perms   │
+                  └───────────┘
+
+     I see three tangles. Which one's burning?
+```
+
+**User is stuck mid-implementation:**
+```
+User: /opsx:explore add-auth-system
+      The OAuth integration is more complex than expected
+
+You: [reads change artifacts]
+
+     You're on task 4: "Implement OAuth flow"
+
+     Let me trace what's involved...
+
+     [draws diagram, explores options, suggests paths]
+
+     Want to update the design to reflect this?
+     Or add a spike task to investigate?
+```
+
+**User wants to compare options:**
+```
+User: Should we use Postgres or SQLite?
+
+You: Generic answer is boring. What's the context?
+
+User: A CLI tool that tracks local dev environments
+
+You: That changes everything.
+
+     ┌─────────────────────────────────────────────────┐
+     │          CLI TOOL DATA STORAGE                  │
+     └─────────────────────────────────────────────────┘
+
+     Key constraints:
+     • No daemon running
+     • Must work offline
+     • Single user
+
+                  SQLite          Postgres
+     Deployment   embedded ✓      needs server ✗
+     Offline      yes ✓           no ✗
+     Single file  yes ✓           no ✗
+
+     SQLite. Not even close.
+
+     Unless... is there a sync component?
+```
+
+---
+
+## Ending Discovery
+
+There's no required ending. Discovery might:
+
+- **Flow into a proposal**: "Ready to start? I can create a change proposal."
+- **Result in artifact updates**: "Updated design.md with these decisions"
+- **Just provide clarity**: User has what they need, moves on
+- **Continue later**: "We can pick this up anytime"
+
+When it feels like things are crystallizing, you might summarize:
+
+```
+## What We Figured Out
+
+**The problem**: [crystallized understanding]
+
+**The approach**: [if one emerged]
+
+**Open questions**: [if any remain]
+
+**Next steps** (if ready):
+- Create a change proposal
+- Keep exploring: just keep talking
+```
+
+But this summary is optional. Sometimes the thinking IS the value.
+
+---
+
+## Guardrails
+
+- **Don't implement** - Never write code or implement features. Creating OpenSpec artifacts is fine, writing application code is not.
+- **Don't fake understanding** - If something is unclear, dig deeper
+- **Don't rush** - Discovery is thinking time, not task time
+- **Don't force structure** - Let patterns emerge naturally
+- **Don't auto-capture** - Offer to save insights, don't just do it
+- **Do visualize** - A good diagram is worth many paragraphs
+- **Do explore the codebase** - Ground discussions in reality
+- **Do question assumptions** - Including the user's and your own

--- a/.claude/skills/openspec-propose/SKILL.md
+++ b/.claude/skills/openspec-propose/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: openspec-propose
+description: Propose a new change with all artifacts generated in one step. Use when the user wants to quickly describe what they want to build and get a complete proposal with design, specs, and tasks ready for implementation.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.3.1"
+---
+
+Propose a new change - create the change and generate all artifacts in one step.
+
+I'll create a change with artifacts:
+- proposal.md (what & why)
+- design.md (how)
+- tasks.md (implementation steps)
+
+When ready to implement, run /opsx:apply
+
+---
+
+**Input**: The user's request should include a change name (kebab-case) OR a description of what they want to build.
+
+**Steps**
+
+1. **If no clear input provided, ask what they want to build**
+
+   Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
+   > "What change do you want to work on? Describe what you want to build or fix."
+
+   From their description, derive a kebab-case name (e.g., "add user authentication" → `add-user-auth`).
+
+   **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
+
+2. **Create the change directory**
+   ```bash
+   openspec new change "<name>"
+   ```
+   This creates a scaffolded change at `openspec/changes/<name>/` with `.openspec.yaml`.
+
+3. **Get the artifact build order**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to get:
+   - `applyRequires`: array of artifact IDs needed before implementation (e.g., `["tasks"]`)
+   - `artifacts`: list of all artifacts with their status and dependencies
+
+4. **Create artifacts in sequence until apply-ready**
+
+   Use the **TodoWrite tool** to track progress through the artifacts.
+
+   Loop through artifacts in dependency order (artifacts with no pending dependencies first):
+
+   a. **For each artifact that is `ready` (dependencies satisfied)**:
+      - Get instructions:
+        ```bash
+        openspec instructions <artifact-id> --change "<name>" --json
+        ```
+      - The instructions JSON includes:
+        - `context`: Project background (constraints for you - do NOT include in output)
+        - `rules`: Artifact-specific rules (constraints for you - do NOT include in output)
+        - `template`: The structure to use for your output file
+        - `instruction`: Schema-specific guidance for this artifact type
+        - `outputPath`: Where to write the artifact
+        - `dependencies`: Completed artifacts to read for context
+      - Read any completed dependency files for context
+      - Create the artifact file using `template` as the structure
+      - Apply `context` and `rules` as constraints - but do NOT copy them into the file
+      - Show brief progress: "Created <artifact-id>"
+
+   b. **Continue until all `applyRequires` artifacts are complete**
+      - After creating each artifact, re-run `openspec status --change "<name>" --json`
+      - Check if every artifact ID in `applyRequires` has `status: "done"` in the artifacts array
+      - Stop when all `applyRequires` artifacts are done
+
+   c. **If an artifact requires user input** (unclear context):
+      - Use **AskUserQuestion tool** to clarify
+      - Then continue with creation
+
+5. **Show final status**
+   ```bash
+   openspec status --change "<name>"
+   ```
+
+**Output**
+
+After completing all artifacts, summarize:
+- Change name and location
+- List of artifacts created with brief descriptions
+- What's ready: "All artifacts created! Ready for implementation."
+- Prompt: "Run `/opsx:apply` or ask me to implement to start working on the tasks."
+
+**Artifact Creation Guidelines**
+
+- Follow the `instruction` field from `openspec instructions` for each artifact type
+- The schema defines what each artifact should contain - follow it
+- Read dependency artifacts for context before creating new ones
+- Use `template` as the structure for your output file - fill in its sections
+- **IMPORTANT**: `context` and `rules` are constraints for YOU, not content for the file
+  - Do NOT copy `<context>`, `<rules>`, `<project_context>` blocks into the artifact
+  - These guide what you write, but should never appear in the output
+
+**Guardrails**
+- Create ALL artifacts needed for implementation (as defined by schema's `apply.requires`)
+- Always read dependency artifacts before creating a new one
+- If context is critically unclear, ask the user - but prefer making reasonable decisions to keep momentum
+- If a change with that name already exists, ask if user wants to continue it or create a new one
+- Verify each artifact file exists after writing before proceeding to next

--- a/DanfeSharp.Test/DanfeCanceladaTests.cs
+++ b/DanfeSharp.Test/DanfeCanceladaTests.cs
@@ -1,0 +1,190 @@
+using System.IO;
+using System.Text;
+using DanfeSharp.Modelo;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using org.pdfclown.tools;
+using PdfFile = org.pdfclown.files.File;
+
+namespace DanfeSharp.Test
+{
+    /// <summary>
+    /// Tests for the cancelled-invoice watermark feature. Covers nfe/DanfeSharp#40.
+    /// See openspec/changes/add-cancelled-watermark/specs/danfe-cancelled-watermark/spec.md
+    /// </summary>
+    [TestClass]
+    public class DanfeCanceladaTests
+    {
+        private const string MarcaDaguaCancelada = "DOCUMENTO CANCELADO";
+
+        public readonly string OutputDirectory = Path.Combine("Output", "DeCancelada");
+        public readonly string InputXmlDirectoryPrefix = Path.Combine("Xml", "NFe");
+
+        public DanfeCanceladaTests()
+        {
+            if (!Directory.Exists(OutputDirectory))
+                Directory.CreateDirectory(OutputDirectory);
+        }
+
+        // === Unit-level: ViewModel default ===
+
+        [TestMethod]
+        public void DanfeViewModel_DefaultIsCancelledFalse()
+        {
+            var vm = new DanfeViewModel();
+            Assert.IsFalse(vm.IsCancelled, "IsCancelled deve ser false por padrão (preserva comportamento anterior).");
+        }
+
+        [TestMethod]
+        public void DanfeViewModel_IsCancelledSettable()
+        {
+            var vm = new DanfeViewModel { IsCancelled = true };
+            Assert.IsTrue(vm.IsCancelled);
+        }
+
+        // === Integration: render PDF + verify watermark presence/absence ===
+
+        private DanfeViewModel CarregarFixture(string fixtureRelative)
+        {
+            var path = Path.Combine(InputXmlDirectoryPrefix, fixtureRelative);
+            return DanfeViewModelCreator.CriarDeArquivoXml(path);
+        }
+
+        private string GerarPdfETexto(DanfeViewModel model, string outFileName)
+        {
+            var pdfPath = Path.Combine(OutputDirectory, outFileName);
+            using (Danfe danfe = new Danfe(model))
+            {
+                danfe.Gerar();
+                danfe.Salvar(pdfPath);
+            }
+            return pdfPath;
+        }
+
+        // Extrai todo o texto renderizado em todas as páginas do PDF usando o
+        // TextExtractor do PDFClown (já dependência do projeto). Permite que os
+        // testes verifiquem presença/ausência da marca d'água sem depender de
+        // ferramenta externa como pdftotext (que não roda em CI puro).
+        private static string ExtrairTextoPdf(string pdfPath)
+        {
+            var sb = new StringBuilder();
+            using (var file = new PdfFile(pdfPath))
+            {
+                var extractor = new TextExtractor();
+                foreach (var page in file.Document.Pages)
+                {
+                    var areaTextStrings = extractor.Extract(page);
+                    foreach (var pair in areaTextStrings)
+                    {
+                        foreach (var textString in pair.Value)
+                        {
+                            sb.AppendLine(textString.Text);
+                        }
+                    }
+                }
+            }
+            return sb.ToString();
+        }
+
+        [TestMethod]
+        public void Render_IsCancelledTrue_DesenhaMarcaCancelada()
+        {
+            var model = CarregarFixture("v4.00/v4_DanfeIntermediario.xml");
+            model.IsCancelled = true;
+            var path = GerarPdfETexto(model, "Intermediario_Cancelada.pdf");
+
+            Assert.IsTrue(File.Exists(path), "PDF deve ser gerado.");
+            Assert.IsTrue(new FileInfo(path).Length > 0, "PDF não pode estar vazio.");
+
+            var texto = ExtrairTextoPdf(path);
+            StringAssert.Contains(texto, MarcaDaguaCancelada,
+                "Conteúdo do PDF deve conter a marca d'água 'DOCUMENTO CANCELADO' quando IsCancelled=true.");
+        }
+
+        [TestMethod]
+        public void Render_cStat101_DesenhaMarcaCancelada()
+        {
+            // Fallback de detecção: quando IsCancelled é false mas o XML traz
+            // cStat=101, a marca também deve aparecer (compat com PR #8/2023).
+            var model = CarregarFixture("v4.00/v4_DanfeIntermediario.xml");
+            model.CodigoStatusReposta = 101;
+            var path = GerarPdfETexto(model, "Intermediario_cStat101.pdf");
+
+            var texto = ExtrairTextoPdf(path);
+            StringAssert.Contains(texto, MarcaDaguaCancelada,
+                "Marca d'água deve aparecer também quando o trigger é cStat=101 (fallback).");
+        }
+
+        [TestMethod]
+        public void Render_AmbosTrigger_NaoLancaExcecao()
+        {
+            // IsCancelled=true E cStat=101 simultaneamente — deve renderizar
+            // sem duplicar marca (Danfe.cs faz OR, então marca aparece uma vez).
+            var model = CarregarFixture("v4.00/v4_DanfeIntermediario.xml");
+            model.IsCancelled = true;
+            model.CodigoStatusReposta = 101;
+            var path = GerarPdfETexto(model, "Intermediario_AmbosTrigger.pdf");
+            Assert.IsTrue(File.Exists(path));
+        }
+
+        [TestMethod]
+        public void Render_NaoCancelada_NaoDesenhaMarcaCancelada()
+        {
+            // Regressão: render normal sem nenhum trigger não deve incluir
+            // a marca d'água — protege contra mudanças que sempre desenhem.
+            var model = CarregarFixture("v4.00/v4_DanfeIntermediario.xml");
+            var path = GerarPdfETexto(model, "Intermediario_NaoCancelada.pdf");
+
+            Assert.IsFalse(model.IsCancelled);
+
+            var texto = ExtrairTextoPdf(path);
+            Assert.IsFalse(texto.Contains(MarcaDaguaCancelada),
+                "Marca d'água NÃO pode aparecer em DANFE não-cancelada (regressão).");
+        }
+
+        // === Demo render: 3 fixtures × cancelada (Mínimo + Intermediário + Completo) ===
+
+        [TestMethod]
+        public void Demo_DanfeMinimo_Cancelada()
+        {
+            var model = CarregarFixture("v4.00/v4_DanfeMinimo.xml");
+            model.IsCancelled = true;
+            GerarPdfETexto(model, "v4_DanfeMinimo_Cancelada.pdf");
+        }
+
+        [TestMethod]
+        public void Demo_DanfeIntermediario_Cancelada()
+        {
+            var model = CarregarFixture("v4.00/v4_DanfeIntermediario.xml");
+            model.IsCancelled = true;
+            GerarPdfETexto(model, "v4_DanfeIntermediario_Cancelada.pdf");
+        }
+
+        [TestMethod]
+        public void Demo_DanfeCompleto_Cancelada()
+        {
+            var model = CarregarFixture("v4.00/v4_DanfeCompleto.xml");
+            model.IsCancelled = true;
+            GerarPdfETexto(model, "v4_DanfeCompleto_Cancelada.pdf");
+        }
+
+        // === Paisagem cancelada (cobertura visual em ambas as orientações) ===
+
+        [TestMethod]
+        public void Demo_DanfeIntermediario_Cancelada_Paisagem()
+        {
+            var model = CarregarFixture("v4.00/v4_DanfeIntermediario.xml");
+            model.IsCancelled = true;
+            model.Orientacao = Orientacao.Paisagem;
+            GerarPdfETexto(model, "v4_DanfeIntermediario_Cancelada_Paisagem.pdf");
+        }
+
+        [TestMethod]
+        public void Demo_DanfeCompleto_Cancelada_Paisagem()
+        {
+            var model = CarregarFixture("v4.00/v4_DanfeCompleto.xml");
+            model.IsCancelled = true;
+            model.Orientacao = Orientacao.Paisagem;
+            GerarPdfETexto(model, "v4_DanfeCompleto_Cancelada_Paisagem.pdf");
+        }
+    }
+}

--- a/DanfeSharp.Test/DanfeSharp.Test.csproj
+++ b/DanfeSharp.Test/DanfeSharp.Test.csproj
@@ -53,6 +53,7 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
+    <Reference Include="System.Xml" />
     <Reference Include="System.Drawing.Common, Version=4.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Drawing.Common.4.5.0-rc1\lib\net461\System.Drawing.Common.dll</HintPath>
     </Reference>
@@ -61,7 +62,10 @@
     <Compile Include="DanfeXmlTests.cs" />
     <Compile Include="Extentions.cs" />
     <Compile Include="FabricaFake.cs" />
+    <Compile Include="DanfeCanceladaTests.cs" />
+    <Compile Include="FormaPagamentoTests.cs" />
     <Compile Include="LogoTests.cs" />
+    <Compile Include="ProdutoIcmsColumnTests.cs" />
     <Compile Include="SimplePdfPageTester.cs" />
     <Compile Include="DanfeTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
@@ -108,6 +112,18 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="Xml\NFe\v4.00\v4_ComLocalRetirada.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Xml\NFe\v4.00\v4_RevendaMaisDemo.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Xml\NFe\v4.00\v4_DanfeMinimo.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Xml\NFe\v4.00\v4_DanfeIntermediario.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Xml\NFe\v4.00\v4_DanfeCompleto.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>

--- a/DanfeSharp.Test/DanfeTest.cs
+++ b/DanfeSharp.Test/DanfeTest.cs
@@ -60,7 +60,7 @@ namespace DanfeSharp.Test
             foreach (var pathXml in Directory.EnumerateFiles(pasta, "*.xml"))
             {
                 var model = DanfeEventoViewModelCreator.CriarDeArquivoXml(pathXml);
-                using (DanfeCCC danfe = new DanfeCCC(model))
+                using (DanfeCartaCorrecao danfe = new DanfeCartaCorrecao(model))
                 {
                     danfe.Gerar();
                     danfe.Salvar($"{caminhoOut}/{model.ChaveAcesso}.pdf");

--- a/DanfeSharp.Test/DanfeXmlTests.cs
+++ b/DanfeSharp.Test/DanfeXmlTests.cs
@@ -46,5 +46,101 @@ namespace DanfeSharp.Test
 
         [TestMethod]
         public void v4_ComLocalRetirada() => TestXml("v4.00/v4_ComLocalRetirada.xml");
+
+        /// <summary>
+        /// Fixture demo construída para exibir os ajustes desta sprint:
+        /// (a) bloco "Forma de Pagamento" com 3 detPag variados (PIX, Cartão
+        /// de Crédito, Outros com xPag="VALE TROCO");
+        /// (b) bloco "Fatura / Duplicata" com 6 duplicatas mensais — mostra
+        /// o novo layout horizontal de campos + a paginação em 2 linhas de 3
+        /// duplicatas cada (numeroElementosLinha=3 em retrato).
+        /// </summary>
+        [TestMethod]
+        public void v4_RevendaMaisDemo() => TestXml("v4.00/v4_RevendaMaisDemo.xml");
+
+        /// <summary>
+        /// Mesma fixture v4_RevendaMaisDemo mas forçando Orientacao=Paisagem.
+        /// O DanfeViewModelCreator hoje hardcoda Retrato (ver
+        /// DanfeViewModelCreator.cs:411 — comentário sobre netcore2.0), então
+        /// para visualizar paisagem precisamos sobrescrever após o load.
+        /// Antes do fix em Danfe.Gerar() (pagar guard de overflow), este teste
+        /// falhava com "Height is invalid" — a fixture rica em paisagem
+        /// fazia os blocos topo consumirem toda a altura. Agora passa: o
+        /// guard pula página sem espaço, próxima página renderiza a tabela.
+        /// </summary>
+        [TestMethod]
+        public void v4_RevendaMaisDemo_Paisagem()
+        {
+            var inputPath = Path.Combine(InputXmlDirectoryPrefix, "v4.00", "v4_RevendaMaisDemo.xml");
+            var outPath = Path.Combine(OutputDirectory, "v4_RevendaMaisDemo_Paisagem.pdf");
+            var model = DanfeViewModelCreator.CriarDeArquivoXml(inputPath);
+            model.Orientacao = Orientacao.Paisagem;
+            using (Danfe danfe = new Danfe(model))
+            {
+                danfe.Gerar();
+                danfe.Salvar(outPath);
+            }
+        }
+
+        /// <summary>
+        /// Versão paisagem da fixture leve (1 duplicata, 1 detPag) para
+        /// confirmar que o pipeline paisagem funciona com NF-e simples —
+        /// isolando se o erro "Height is invalid" do demo paisagem é por
+        /// overflow de conteúdo (6 duplicatas + 3 detPag) ou bug geral.
+        /// </summary>
+        [TestMethod]
+        public void v4_ComLocalEntrega_Paisagem()
+        {
+            var inputPath = Path.Combine(InputXmlDirectoryPrefix, "v4.00", "v4_ComLocalEntrega.xml");
+            var outPath = Path.Combine(OutputDirectory, "v4_ComLocalEntrega_Paisagem.pdf");
+            var model = DanfeViewModelCreator.CriarDeArquivoXml(inputPath);
+            model.Orientacao = Orientacao.Paisagem;
+            using (Danfe danfe = new Danfe(model))
+            {
+                danfe.Gerar();
+                danfe.Salvar(outPath);
+            }
+        }
+
+        // === Fixtures de demonstração geradas por generate-fixtures.sh ===
+
+        /// <summary>DANFE mínimo: 1 item, sem cobr, sem pag, sem infAdProd.</summary>
+        [TestMethod]
+        public void v4_DanfeMinimo() => TestXml("v4.00/v4_DanfeMinimo.xml");
+
+        /// <summary>DANFE intermediário: 5 itens (3 com infAdProd), 2 duplicatas, 2 detPag.</summary>
+        [TestMethod]
+        public void v4_DanfeIntermediario() => TestXml("v4.00/v4_DanfeIntermediario.xml");
+
+        /// <summary>DANFE completo: 20 itens (todos com infAdProd), 6 duplicatas, 3 detPag.</summary>
+        [TestMethod]
+        public void v4_DanfeCompleto() => TestXml("v4.00/v4_DanfeCompleto.xml");
+
+        // === Mesmas 3 fixtures, mas em PAISAGEM (override de Orientacao) ===
+
+        private void RenderPaisagem(string xmlRelativePath, string outFileName)
+        {
+            var inputPath = Path.Combine(InputXmlDirectoryPrefix, xmlRelativePath);
+            var outPath = Path.Combine(OutputDirectory, outFileName);
+            var model = DanfeViewModelCreator.CriarDeArquivoXml(inputPath);
+            model.Orientacao = Orientacao.Paisagem;
+            using (Danfe danfe = new Danfe(model))
+            {
+                danfe.Gerar();
+                danfe.Salvar(outPath);
+            }
+        }
+
+        [TestMethod]
+        public void v4_DanfeMinimo_Paisagem() =>
+            RenderPaisagem("v4.00/v4_DanfeMinimo.xml", "v4_DanfeMinimo_Paisagem.pdf");
+
+        [TestMethod]
+        public void v4_DanfeIntermediario_Paisagem() =>
+            RenderPaisagem("v4.00/v4_DanfeIntermediario.xml", "v4_DanfeIntermediario_Paisagem.pdf");
+
+        [TestMethod]
+        public void v4_DanfeCompleto_Paisagem() =>
+            RenderPaisagem("v4.00/v4_DanfeCompleto.xml", "v4_DanfeCompleto_Paisagem.pdf");
     }
 }

--- a/DanfeSharp.Test/FabricaFake.cs
+++ b/DanfeSharp.Test/FabricaFake.cs
@@ -48,7 +48,7 @@ namespace DanfeSharp.Test
                 ValorSeguro = v,
                 ValorTotalNota = v,
                 ValorTotalProdutos = v,
-                vFCPUFDest = v,
+                vFCPUFDest = (decimal?)v,
                 vICMSUFDest = v,
                 vICMSUFRemet = v
             };

--- a/DanfeSharp.Test/FormaPagamentoTests.cs
+++ b/DanfeSharp.Test/FormaPagamentoTests.cs
@@ -1,0 +1,250 @@
+using System.IO;
+using System.Xml.Serialization;
+using DanfeSharp.Modelo;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+// Aliases para desambiguar os dois enums FormaPagamento que coexistem
+// no projeto (um em DanfeSharp/Enums.cs, outro em DanfeSharp/Esquemas/ProcNFe.cs).
+using FormaPagamentoVm = DanfeSharp.FormaPagamento;
+using FormaPagamentoSchema = DanfeSharp.Esquemas.NFe.FormaPagamento;
+using detPagSchema = DanfeSharp.Esquemas.NFe.detPag;
+
+namespace DanfeSharp.Test
+{
+    /// <summary>
+    /// Tests for the FORMA DE PAGAMENTO block rendering in DANFE NF-e modelo 55.
+    /// Covers nfe/DanfeSharp#39.
+    /// See openspec/changes/add-danfe-payment-block/specs/danfe-payment-block/spec.md
+    /// </summary>
+    [TestClass]
+    public class FormaPagamentoTests
+    {
+        // === Helper FormaPagamentoExtensions.GetDescricao ===
+
+        [TestMethod]
+        public void GetDescricao_Dinheiro_RetornaDinheiro()
+        {
+            Assert.AreEqual("Dinheiro", FormaPagamentoVm.fpDinheiro.GetDescricao());
+        }
+
+        [TestMethod]
+        public void GetDescricao_CartaoCredito_RetornaCartaoCredito()
+        {
+            Assert.AreEqual("Cartão de Crédito", FormaPagamentoVm.fpCartaoCredito.GetDescricao());
+        }
+
+        [TestMethod]
+        public void GetDescricao_CartaoDebito_RetornaCartaoDebito()
+        {
+            Assert.AreEqual("Cartão de Débito", FormaPagamentoVm.fpCartaoDebito.GetDescricao());
+        }
+
+        [TestMethod]
+        public void GetDescricao_Outros_RetornaOutros()
+        {
+            Assert.AreEqual("Outros", FormaPagamentoVm.fpOutro.GetDescricao());
+        }
+
+        [TestMethod]
+        public void GetDescricao_Pix_RetornaDescricaoNaoVazia()
+        {
+            // tPag=17 (Pagamento Instantâneo - PIX, NT 2020.001)
+            var resultado = FormaPagamentoVm.fpPagamentoInstantaneoPIX.GetDescricao();
+            Assert.IsFalse(string.IsNullOrEmpty(resultado), "PIX deve ter descrição não-vazia");
+        }
+
+        [TestMethod]
+        public void GetDescricao_ValorInvalido_RetornaStringVazia()
+        {
+            // Valor fora do enum (defesa em profundidade contra XML com tPag novo)
+            var resultado = ((FormaPagamentoVm)999).GetDescricao();
+            Assert.AreEqual(string.Empty, resultado);
+        }
+
+        // === Schema parsing — detPag.xPag deserialization ===
+
+        private detPagSchema DeserializarDetPag(string xml)
+        {
+            var serializer = new XmlSerializer(typeof(detPagSchema));
+            using (var reader = new StringReader(xml))
+            {
+                return (detPagSchema)serializer.Deserialize(reader);
+            }
+        }
+
+        [TestMethod]
+        public void Schema_XmlComXPag_DeserializaCampo()
+        {
+            var xml = @"<?xml version='1.0'?>
+                <detPag>
+                    <tPag>99</tPag>
+                    <xPag>RECURSOS PROPRIOS</xPag>
+                    <vPag>48000.00</vPag>
+                </detPag>";
+
+            var detPag = DeserializarDetPag(xml);
+
+            Assert.AreEqual("RECURSOS PROPRIOS", detPag.xPag);
+            Assert.AreEqual(FormaPagamentoSchema.fpOutro, detPag.tPag);
+            Assert.AreEqual(48000.00m, detPag.vPag);
+        }
+
+        [TestMethod]
+        public void Schema_XmlSemXPag_RetornaNull()
+        {
+            var xml = @"<?xml version='1.0'?>
+                <detPag>
+                    <tPag>01</tPag>
+                    <vPag>100.00</vPag>
+                </detPag>";
+
+            var detPag = DeserializarDetPag(xml);
+
+            Assert.IsNull(detPag.xPag);
+            Assert.AreEqual(FormaPagamentoSchema.fpDinheiro, detPag.tPag);
+        }
+
+        [TestMethod]
+        public void Schema_XmlComXPagVazio_RetornaStringVazia()
+        {
+            // Edge case: <xPag></xPag> presente mas sem conteúdo
+            var xml = @"<?xml version='1.0'?>
+                <detPag>
+                    <tPag>01</tPag>
+                    <xPag></xPag>
+                    <vPag>100.00</vPag>
+                </detPag>";
+
+            var detPag = DeserializarDetPag(xml);
+
+            // XmlSerializer entrega string.Empty para elemento vazio
+            // (o producer normaliza para null antes de chegar ao ViewModel)
+            Assert.IsTrue(string.IsNullOrEmpty(detPag.xPag));
+        }
+
+        // === DetalheViewModel.Descricao ===
+
+        [TestMethod]
+        public void ViewModel_DescricaoSettable()
+        {
+            var detalhe = new DetalheViewModel
+            {
+                FormaPagamento = FormaPagamentoVm.fpOutro,
+                Descricao = "BOLETO BB",
+                Valor = 500m
+            };
+
+            Assert.AreEqual("BOLETO BB", detalhe.Descricao);
+            Assert.AreEqual(FormaPagamentoVm.fpOutro, detalhe.FormaPagamento);
+        }
+
+        [TestMethod]
+        public void ViewModel_DescricaoNullPorDefault()
+        {
+            var detalhe = new DetalheViewModel
+            {
+                FormaPagamento = FormaPagamentoVm.fpDinheiro,
+                Valor = 100m
+            };
+
+            Assert.IsNull(detalhe.Descricao);
+        }
+
+        // === Integration: helper + viewmodel + selection rule ===
+
+        [TestMethod]
+        public void DescricaoPrevalecesoSobreEnum_QuandoAmbosPresentes()
+        {
+            // Regra da spec: quando Descricao preenchido, prevalece sobre [Description] do enum
+            var detalhe = new DetalheViewModel
+            {
+                FormaPagamento = FormaPagamentoVm.fpCartaoCredito,  // descricao default: "Cartão de Crédito"
+                Descricao = "VISA 4× 2,5%",
+                Valor = 100m
+            };
+
+            var resultado = !string.IsNullOrEmpty(detalhe.Descricao)
+                ? detalhe.Descricao
+                : detalhe.FormaPagamento.GetDescricao();
+
+            Assert.AreEqual("VISA 4× 2,5%", resultado);
+        }
+
+        [TestMethod]
+        public void EnumDescricaoUsadoComoFallback_QuandoDescricaoEhNull()
+        {
+            var detalhe = new DetalheViewModel
+            {
+                FormaPagamento = FormaPagamentoVm.fpDinheiro,
+                Descricao = null,
+                Valor = 100m
+            };
+
+            var resultado = !string.IsNullOrEmpty(detalhe.Descricao)
+                ? detalhe.Descricao
+                : detalhe.FormaPagamento.GetDescricao();
+
+            Assert.AreEqual("Dinheiro", resultado);
+        }
+
+        [TestMethod]
+        public void TPag99SemDescricao_RetornaOutrosComoFallback()
+        {
+            // Edge case: XML mal-formado com tPag=99 mas sem xPag
+            var detalhe = new DetalheViewModel
+            {
+                FormaPagamento = FormaPagamentoVm.fpOutro,
+                Descricao = null,
+                Valor = 100m
+            };
+
+            var resultado = !string.IsNullOrEmpty(detalhe.Descricao)
+                ? detalhe.Descricao
+                : detalhe.FormaPagamento.GetDescricao();
+
+            Assert.AreEqual("Outros", resultado);
+        }
+    }
+}
+
+namespace DanfeSharp.Test
+{
+    using System.IO;
+    using DanfeSharp.Modelo;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    /// <summary>
+    /// Integration tests garantindo que o producer (CreateFromProcNFe) popula
+    /// model.Pagamento a partir do XML — bug #39 raiz: a população estava só
+    /// em CreateFromProcNFCe (modelo 65), faltava em CreateFromProcNFe
+    /// (modelo 55).
+    /// </summary>
+    [TestClass]
+    public class IntegracaoPagamentoNFe
+    {
+        [TestMethod]
+        public void V4ComLocalEntrega_PopulaPagamentoDoGrupoPag()
+        {
+            var path = Path.Combine("Xml", "NFe", "v4.00", "v4_ComLocalEntrega.xml");
+            var model = DanfeViewModelCreator.CriarDeArquivoXml(path);
+
+            Assert.IsNotNull(model.Pagamento, "ViewModel.Pagamento não deve ser null");
+            Assert.IsTrue(model.Pagamento.Count > 0,
+                "model.Pagamento.Count==0 indica que CreateFromProcNFe não populou — checar regressão do fix #39");
+
+            var detalhe = model.Pagamento[0].DetalhePagamento[0];
+            Assert.AreEqual(3977.00m, detalhe.Valor);
+            Assert.AreEqual(DanfeSharp.FormaPagamento.fpOutro, detalhe.FormaPagamento);
+        }
+
+        [TestMethod]
+        public void V3_10Retrato_SemPag_NaoQuebraEPagamentoFicaVazio()
+        {
+            // Regressão: NF-e antiga sem <pag> no XML continua válida
+            var path = Path.Combine("Xml", "NFe", "v3.10", "v3.10_Retrato.xml");
+            var model = DanfeViewModelCreator.CriarDeArquivoXml(path);
+
+            Assert.IsNotNull(model.Pagamento);
+            Assert.AreEqual(0, model.Pagamento.Count);
+        }
+    }
+}

--- a/DanfeSharp.Test/ProdutoIcmsColumnTests.cs
+++ b/DanfeSharp.Test/ProdutoIcmsColumnTests.cs
@@ -1,0 +1,154 @@
+using System.Collections.Generic;
+using DanfeSharp.Modelo;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace DanfeSharp.Test
+{
+    /// <summary>
+    /// Tests for the ICMS column (origem + CST/CSOSN) rendering in the
+    /// DANFE product table. Covers the fix for nfe/DanfeSharp#38.
+    /// See openspec/changes/fix-danfe-csosn-rendering/specs/danfe-icms-column/spec.md
+    /// </summary>
+    [TestClass]
+    public class ProdutoIcmsColumnTests
+    {
+        // === ProdutoViewModel.OCst — cell composition rules ===
+
+        [TestMethod]
+        public void OCst_RegimeNormal_OrigemComCst_RetornaOrigemBarraCst()
+        {
+            var produto = new ProdutoViewModel { Origem = "1", Cst = "20" };
+            Assert.AreEqual("1/20", produto.OCst);
+        }
+
+        [TestMethod]
+        public void OCst_SimplesNacional_OrigemComCsosn_RetornaOrigemBarraCsosn()
+        {
+            var produto = new ProdutoViewModel { Origem = "0", Csosn = "102" };
+            Assert.AreEqual("0/102", produto.OCst);
+        }
+
+        [TestMethod]
+        public void OCst_SemOrigem_ApenasCst_RetornaCodigoSemBarra()
+        {
+            var produto = new ProdutoViewModel { Cst = "40" };
+            Assert.AreEqual("40", produto.OCst);
+        }
+
+        [TestMethod]
+        public void OCst_SemOrigem_ApenasCsosn_RetornaCodigoSemBarra()
+        {
+            var produto = new ProdutoViewModel { Csosn = "500" };
+            Assert.AreEqual("500", produto.OCst);
+        }
+
+        [TestMethod]
+        public void OCst_ApenasOrigem_SemCstNemCsosn_RetornaOrigemSemBarra()
+        {
+            var produto = new ProdutoViewModel { Origem = "2" };
+            Assert.AreEqual("2", produto.OCst);
+        }
+
+        [TestMethod]
+        public void OCst_TodosNull_RetornaStringVazia()
+        {
+            var produto = new ProdutoViewModel();
+            Assert.AreEqual(string.Empty, produto.OCst);
+        }
+
+        [TestMethod]
+        public void OCst_OrigemEmString_TrataComoAusente()
+        {
+            // O ProcNFe deserializer pode entregar "" para tags ausentes;
+            // o producer normaliza para null, mas o OCst computado deve
+            // tratar "" como ausente também, para defesa em profundidade.
+            var produto = new ProdutoViewModel { Origem = "", Cst = "20" };
+            Assert.AreEqual("20", produto.OCst);
+        }
+
+        [TestMethod]
+        public void OCst_CstPreferidoSobreCsosn_QuandoAmbosPresentes()
+        {
+            // Caso teoricamente impossível (CST e CSOSN mutuamente exclusivos
+            // por item), mas se aparecer prevalece CST por convenção.
+            var produto = new ProdutoViewModel { Origem = "1", Cst = "20", Csosn = "102" };
+            Assert.AreEqual("1/20", produto.OCst);
+        }
+
+        // === ProdutoViewModel.CalcularCabecalhoColunaIcms — dynamic header ===
+
+        [TestMethod]
+        public void Cabecalho_TodosItensComCst_RetornaOCST()
+        {
+            var produtos = new List<ProdutoViewModel>
+            {
+                new ProdutoViewModel { Origem = "1", Cst = "20" },
+                new ProdutoViewModel { Origem = "0", Cst = "00" },
+                new ProdutoViewModel { Origem = "1", Cst = "40" }
+            };
+            Assert.AreEqual("O/CST", ProdutoViewModel.CalcularCabecalhoColunaIcms(produtos));
+        }
+
+        [TestMethod]
+        public void Cabecalho_TodosItensComCsosn_RetornaOCSOSN()
+        {
+            var produtos = new List<ProdutoViewModel>
+            {
+                new ProdutoViewModel { Origem = "0", Csosn = "102" },
+                new ProdutoViewModel { Origem = "0", Csosn = "500" }
+            };
+            Assert.AreEqual("O/CSOSN", ProdutoViewModel.CalcularCabecalhoColunaIcms(produtos));
+        }
+
+        [TestMethod]
+        public void Cabecalho_NenhumItemComCodigo_RetornaOCSTFallback()
+        {
+            var produtos = new List<ProdutoViewModel>
+            {
+                new ProdutoViewModel { Origem = "1" },
+                new ProdutoViewModel()
+            };
+            Assert.AreEqual("O/CST", ProdutoViewModel.CalcularCabecalhoColunaIcms(produtos));
+        }
+
+        [TestMethod]
+        public void Cabecalho_ProdutosNull_RetornaOCSTFallback()
+        {
+            Assert.AreEqual("O/CST", ProdutoViewModel.CalcularCabecalhoColunaIcms(null));
+        }
+
+        [TestMethod]
+        public void Cabecalho_ListaVazia_RetornaOCSTFallback()
+        {
+            Assert.AreEqual("O/CST", ProdutoViewModel.CalcularCabecalhoColunaIcms(new List<ProdutoViewModel>()));
+        }
+
+        [TestMethod]
+        public void Cabecalho_MistoCstECsosn_PrevalenceCst()
+        {
+            // Cenário teoricamente impossível pelo MOC (regime é por emitente,
+            // não por item), mas se aparecer no XML, "O/CST" prevalece.
+            var produtos = new List<ProdutoViewModel>
+            {
+                new ProdutoViewModel { Cst = "20" },
+                new ProdutoViewModel { Csosn = "102" }
+            };
+            Assert.AreEqual("O/CST", ProdutoViewModel.CalcularCabecalhoColunaIcms(produtos));
+        }
+
+        [TestMethod]
+        public void Cabecalho_RegressaoBug38_RevendaMaisComCstESemEmitenteCRT()
+        {
+            // Cenário concreto reportado pelo cliente Revenda Mais
+            // (invoice 86fed76fd38f42e1833375e33a94567c): XML do emitente
+            // sem <CRT>, mas itens têm <CST>. Antes do fix #38, o cabeçalho
+            // caía em "O/CSOSN" porque o código checava só Emitente.CRT.
+            // Após o fix, deriva dos itens e mostra "O/CST" corretamente.
+            var produtos = new List<ProdutoViewModel>
+            {
+                new ProdutoViewModel { Origem = "1", Cst = "20" }
+            };
+            Assert.AreEqual("O/CST", ProdutoViewModel.CalcularCabecalhoColunaIcms(produtos));
+        }
+    }
+}

--- a/DanfeSharp.Test/Xml/NFe/v4.00/generate-fixtures.sh
+++ b/DanfeSharp.Test/Xml/NFe/v4.00/generate-fixtures.sh
@@ -1,0 +1,365 @@
+#!/usr/bin/env bash
+# Gerador das fixtures de demonstração da PR #42 (#39).
+# Produz 3 XMLs de NF-e modelo 55 v4.00 cobrindo cenários distintos:
+#   - v4_DanfeMinimo.xml         (1 item, sem cobr, sem pag)
+#   - v4_DanfeIntermediario.xml  (5 itens, 2 duplicatas, 2 detPag, mix infAdProd)
+#   - v4_DanfeCompleto.xml       (20 itens, 6 duplicatas, 3 detPag, todos infAdProd)
+#
+# Re-execute esse script se precisar regenerar:
+#   bash DanfeSharp.Test/Xml/NFe/v4.00/generate-fixtures.sh
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+# ----- Helpers -----
+gen_item() {
+    local nItem=$1
+    local descricao=$2
+    local vProd=$3
+    local with_infAdProd=$4   # "yes" | "no"
+    local infText="${5:-}"
+
+    local vBC=$vProd
+    local vICMS=$(awk -v v="$vProd" 'BEGIN{ printf "%.2f", v*0.12 }')
+    local vPIS=$(awk -v v="$vProd" 'BEGIN{ printf "%.2f", v*0.0165 }')
+    local vCOFINS=$(awk -v v="$vProd" 'BEGIN{ printf "%.2f", v*0.076 }')
+
+    cat <<XMLITEM
+            <det nItem="$nItem">
+                <prod>
+                    <cProd>PROD-$nItem</cProd>
+                    <cEAN>SEM GTIN</cEAN>
+                    <xProd>$descricao</xProd>
+                    <NCM>49111090</NCM>
+                    <CFOP>5102</CFOP>
+                    <uCom>UN</uCom>
+                    <qCom>1.0000</qCom>
+                    <vUnCom>$vProd</vUnCom>
+                    <vProd>$vProd</vProd>
+                    <cEANTrib>SEM GTIN</cEANTrib>
+                    <uTrib>UN</uTrib>
+                    <qTrib>1.0000</qTrib>
+                    <vUnTrib>$vProd</vUnTrib>
+                    <indTot>1</indTot>
+                </prod>
+                <imposto>
+                    <ICMS>
+                        <ICMS00>
+                            <orig>0</orig>
+                            <CST>00</CST>
+                            <modBC>3</modBC>
+                            <vBC>$vBC</vBC>
+                            <pICMS>12.00</pICMS>
+                            <vICMS>$vICMS</vICMS>
+                        </ICMS00>
+                    </ICMS>
+                    <PIS>
+                        <PISAliq>
+                            <CST>01</CST>
+                            <vBC>$vBC</vBC>
+                            <pPIS>1.65</pPIS>
+                            <vPIS>$vPIS</vPIS>
+                        </PISAliq>
+                    </PIS>
+                    <COFINS>
+                        <COFINSAliq>
+                            <CST>01</CST>
+                            <vBC>$vBC</vBC>
+                            <pCOFINS>7.60</pCOFINS>
+                            <vCOFINS>$vCOFINS</vCOFINS>
+                        </COFINSAliq>
+                    </COFINS>
+                </imposto>
+XMLITEM
+    if [ "$with_infAdProd" = "yes" ]; then
+        echo "                <infAdProd>$infText</infAdProd>"
+    fi
+    echo "            </det>"
+}
+
+gen_dup() {
+    local nDup=$1
+    local dVenc=$2
+    local vDup=$3
+    cat <<XMLDUP
+                <dup>
+                    <nDup>$nDup</nDup>
+                    <dVenc>$dVenc</dVenc>
+                    <vDup>$vDup</vDup>
+                </dup>
+XMLDUP
+}
+
+gen_detpag() {
+    local tPag=$1
+    local vPag=$2
+    local xPag=${3:-}
+    if [ -n "$xPag" ]; then
+        cat <<XMLP
+                <detPag>
+                    <tPag>$tPag</tPag>
+                    <xPag>$xPag</xPag>
+                    <vPag>$vPag</vPag>
+                </detPag>
+XMLP
+    else
+        cat <<XMLP
+                <detPag>
+                    <tPag>$tPag</tPag>
+                    <vPag>$vPag</vPag>
+                </detPag>
+XMLP
+    fi
+}
+
+# Header comum (emit / dest / transp / protocolo). Argumentos: chavePad (38 dígitos), nNF, vTot
+# A chave de acesso da NF-e tem 44 dígitos NUMÉRICOS (sem letras) — concatenamos
+# o prefixo padrão "351105" + 38 dígitos do chavePad.
+gen_header() {
+    local chavePad=$1
+    local nNF=$2
+    local vTot=$3
+    local vICMS=$(awk -v v="$vTot" 'BEGIN{ printf "%.2f", v*0.12 }')
+    local vPIS=$(awk -v v="$vTot" 'BEGIN{ printf "%.2f", v*0.0165 }')
+    local vCOFINS=$(awk -v v="$vTot" 'BEGIN{ printf "%.2f", v*0.076 }')
+
+    cat <<XMLHDR
+<?xml version="1.0" encoding="UTF-8"?>
+<nfeProc versao="4.00" xmlns="http://www.portalfiscal.inf.br/nfe">
+    <NFe xmlns="http://www.portalfiscal.inf.br/nfe">
+        <infNFe Id="NFe351105${chavePad}" versao="4.00">
+            <ide>
+                <cUF>35</cUF>
+                <cNF>$nNF</cNF>
+                <natOp>VENDA</natOp>
+                <mod>55</mod>
+                <serie>1</serie>
+                <nNF>$nNF</nNF>
+                <dhEmi>2026-05-28T14:00:00-03:00</dhEmi>
+                <dhSaiEnt>2026-05-28T14:00:00-03:00</dhSaiEnt>
+                <tpNF>1</tpNF>
+                <idDest>1</idDest>
+                <cMunFG>3550308</cMunFG>
+                <tpImp>1</tpImp>
+                <tpEmis>1</tpEmis>
+                <cDV>1</cDV>
+                <tpAmb>1</tpAmb>
+                <finNFe>1</finNFe>
+                <indFinal>1</indFinal>
+                <indPres>1</indPres>
+                <procEmi>0</procEmi>
+                <verProc>1.0</verProc>
+            </ide>
+            <emit>
+                <CNPJ>22257735000138</CNPJ>
+                <xNome>Demo Emitente LTDA</xNome>
+                <xFant>Demo Co</xFant>
+                <enderEmit>
+                    <xLgr>Av. Demo</xLgr>
+                    <nro>100</nro>
+                    <xBairro>Centro</xBairro>
+                    <cMun>3550308</cMun>
+                    <xMun>São Paulo</xMun>
+                    <UF>SP</UF>
+                    <CEP>01000000</CEP>
+                    <cPais>1058</cPais>
+                    <xPais>BRASIL</xPais>
+                    <fone>1133334444</fone>
+                </enderEmit>
+                <IE>123456789012</IE>
+                <CRT>3</CRT>
+            </emit>
+            <dest>
+                <CNPJ>11222333000181</CNPJ>
+                <xNome>Demo Destinatário S/A</xNome>
+                <enderDest>
+                    <xLgr>Rua Cliente</xLgr>
+                    <nro>200</nro>
+                    <xBairro>Bairro Cliente</xBairro>
+                    <cMun>3550308</cMun>
+                    <xMun>São Paulo</xMun>
+                    <UF>SP</UF>
+                    <CEP>02000000</CEP>
+                    <cPais>1058</cPais>
+                    <xPais>BRASIL</xPais>
+                </enderDest>
+                <indIEDest>9</indIEDest>
+            </dest>
+XMLHDR
+}
+
+# Footer comum (ICMSTot, transp, infAdic, protocolo). Argumentos: vTot, [cobr_xml], [pag_xml]
+gen_footer() {
+    local vTot=$1
+    local cobr_block=${2:-}
+    local pag_block=${3:-}
+    local vICMS=$(awk -v v="$vTot" 'BEGIN{ printf "%.2f", v*0.12 }')
+    local vPIS=$(awk -v v="$vTot" 'BEGIN{ printf "%.2f", v*0.0165 }')
+    local vCOFINS=$(awk -v v="$vTot" 'BEGIN{ printf "%.2f", v*0.076 }')
+
+    cat <<XMLFOOT
+            <total>
+                <ICMSTot>
+                    <vBC>$vTot</vBC>
+                    <vICMS>$vICMS</vICMS>
+                    <vICMSDeson>0.00</vICMSDeson>
+                    <vFCP>0.00</vFCP>
+                    <vBCST>0.00</vBCST>
+                    <vST>0.00</vST>
+                    <vFCPST>0.00</vFCPST>
+                    <vFCPSTRet>0.00</vFCPSTRet>
+                    <vProd>$vTot</vProd>
+                    <vFrete>0.00</vFrete>
+                    <vSeg>0.00</vSeg>
+                    <vDesc>0.00</vDesc>
+                    <vII>0.00</vII>
+                    <vIPI>0.00</vIPI>
+                    <vIPIDevol>0.00</vIPIDevol>
+                    <vPIS>$vPIS</vPIS>
+                    <vCOFINS>$vCOFINS</vCOFINS>
+                    <vOutro>0.00</vOutro>
+                    <vNF>$vTot</vNF>
+                    <vTotTrib>0.00</vTotTrib>
+                </ICMSTot>
+            </total>
+            <transp>
+                <modFrete>9</modFrete>
+            </transp>
+XMLFOOT
+    if [ -n "$cobr_block" ]; then
+        echo "$cobr_block"
+    fi
+    if [ -n "$pag_block" ]; then
+        echo "$pag_block"
+    fi
+    cat <<'XMLFOOT2'
+            <infAdic>
+                <infCpl>Fixture sintética gerada por generate-fixtures.sh para demo da PR #42.</infCpl>
+            </infAdic>
+        </infNFe>
+    </NFe>
+    <protNFe versao="4.00">
+        <infProt>
+            <tpAmb>1</tpAmb>
+            <verAplic>SP</verAplic>
+            <chNFe>35110501000000000000000000000000000000000000</chNFe>
+            <dhRecbto>2026-05-28T14:01:00-03:00</dhRecbto>
+            <nProt>135260000000000</nProt>
+            <digVal>aaa=</digVal>
+            <cStat>100</cStat>
+            <xMotivo>Autorizado o uso da NF-e</xMotivo>
+        </infProt>
+    </protNFe>
+</nfeProc>
+XMLFOOT2
+}
+
+# ===========================================================================
+# 1. v4_DanfeMinimo.xml — 1 item, sem cobr, sem pag, sem infAdProd
+# ===========================================================================
+{
+    gen_header "10000000000000000000000000000000000001" "100000001" "50.00"
+    gen_item 1 "Caneta esferográfica azul" "50.00" "no"
+    gen_footer "50.00" "" ""
+} > v4_DanfeMinimo.xml
+echo "✓ v4_DanfeMinimo.xml gerado"
+
+# ===========================================================================
+# 2. v4_DanfeIntermediario.xml — 5 itens (3 com infAdProd, 2 sem),
+#                                 2 duplicatas, 2 detPag
+# ===========================================================================
+TOTAL_INTER="1000.00"
+{
+    gen_header "20000000000000000000000000000000000002" "200000001" "$TOTAL_INTER"
+    gen_item 1 "Notebook Demo Modelo X" "300.00" "yes" "S/N: NB-001 · Garantia: 12 meses"
+    gen_item 2 "Mouse sem fio bluetooth"  "50.00" "no"
+    gen_item 3 "Teclado mecânico ABNT2"  "200.00" "yes" "Switch: Cherry MX Brown · Layout: ABNT2"
+    gen_item 4 "Cabo USB-C 1m"             "30.00" "no"
+    gen_item 5 "Monitor 24 polegadas"    "420.00" "yes" "Resolução: 1920x1080 · 75Hz · Modelo: MN-24FHD"
+    cobr_inter=$(cat <<XMLCOBR
+            <cobr>
+                <fat>
+                    <nFat>200000001</nFat>
+                    <vOrig>$TOTAL_INTER</vOrig>
+                    <vDesc>0.00</vDesc>
+                    <vLiq>$TOTAL_INTER</vLiq>
+                </fat>
+$(gen_dup "001" "2026-06-28" "500.00")$(gen_dup "002" "2026-07-28" "500.00")
+            </cobr>
+XMLCOBR
+)
+    pag_inter=$(cat <<XMLPAG
+            <pag>
+$(gen_detpag "03" "600.00")$(gen_detpag "17" "400.00")
+            </pag>
+XMLPAG
+)
+    gen_footer "$TOTAL_INTER" "$cobr_inter" "$pag_inter"
+} > v4_DanfeIntermediario.xml
+echo "✓ v4_DanfeIntermediario.xml gerado"
+
+# ===========================================================================
+# 3. v4_DanfeCompleto.xml — 20 itens (todos com infAdProd),
+#                           6 duplicatas, 3 detPag
+# ===========================================================================
+TOTAL_COMP="2000.00"
+PER_ITEM="100.00"
+ITEM_DESCRICOES=(
+    "Item demo A — material de escritório"
+    "Item demo B — papelaria fina"
+    "Item demo C — suprimento gráfico"
+    "Item demo D — material para eventos"
+    "Item demo E — kit de apresentação"
+    "Item demo F — material institucional"
+    "Item demo G — embalagem premium"
+    "Item demo H — material de divulgação"
+    "Item demo I — kit corporativo"
+    "Item demo J — material expositor"
+    "Item demo K — brinde personalizado"
+    "Item demo L — material para feira"
+    "Item demo M — kit promocional"
+    "Item demo N — embalagem padrão"
+    "Item demo O — papel timbrado"
+    "Item demo P — material de campanha"
+    "Item demo Q — bobina térmica"
+    "Item demo R — bloco de notas"
+    "Item demo S — agenda corporativa"
+    "Item demo T — calendário 2026"
+)
+{
+    gen_header "30000000000000000000000000000000000003" "300000001" "$TOTAL_COMP"
+    for i in $(seq 1 20); do
+        idx=$((i-1))
+        gen_item "$i" "${ITEM_DESCRICOES[$idx]}" "$PER_ITEM" "yes" "Lote LT-$i-2026 · Validade 12 meses · Origem: Brasil"
+    done
+    DUP_MES=("2026-06-30" "2026-07-30" "2026-08-30" "2026-09-30" "2026-10-30" "2026-11-30")
+    cobr_comp_dups=""
+    for j in $(seq 0 5); do
+        n=$(printf "%03d" $((j+1)))
+        cobr_comp_dups+=$(gen_dup "$n" "${DUP_MES[$j]}" "333.34")
+    done
+    cobr_comp=$(cat <<XMLCOBR
+            <cobr>
+                <fat>
+                    <nFat>300000001</nFat>
+                    <vOrig>$TOTAL_COMP</vOrig>
+                    <vDesc>0.00</vDesc>
+                    <vLiq>2000.04</vLiq>
+                </fat>
+${cobr_comp_dups}
+            </cobr>
+XMLCOBR
+)
+    pag_comp=$(cat <<XMLPAG
+            <pag>
+$(gen_detpag "17" "800.00")$(gen_detpag "03" "700.00")$(gen_detpag "99" "500.00" "PROMOCIONAL BLACK FRIDAY")
+            </pag>
+XMLPAG
+)
+    gen_footer "$TOTAL_COMP" "$cobr_comp" "$pag_comp"
+} > v4_DanfeCompleto.xml
+echo "✓ v4_DanfeCompleto.xml gerado"
+
+echo ""
+echo "=== Arquivos gerados ==="
+ls -la v4_Danfe*.xml

--- a/DanfeSharp.Test/Xml/NFe/v4.00/v4_DanfeCompleto.xml
+++ b/DanfeSharp.Test/Xml/NFe/v4.00/v4_DanfeCompleto.xml
@@ -1,0 +1,1092 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<nfeProc versao="4.00" xmlns="http://www.portalfiscal.inf.br/nfe">
+    <NFe xmlns="http://www.portalfiscal.inf.br/nfe">
+        <infNFe Id="NFe35110530000000000000000000000000000000000003" versao="4.00">
+            <ide>
+                <cUF>35</cUF>
+                <cNF>300000001</cNF>
+                <natOp>VENDA</natOp>
+                <mod>55</mod>
+                <serie>1</serie>
+                <nNF>300000001</nNF>
+                <dhEmi>2026-05-28T14:00:00-03:00</dhEmi>
+                <dhSaiEnt>2026-05-28T14:00:00-03:00</dhSaiEnt>
+                <tpNF>1</tpNF>
+                <idDest>1</idDest>
+                <cMunFG>3550308</cMunFG>
+                <tpImp>1</tpImp>
+                <tpEmis>1</tpEmis>
+                <cDV>1</cDV>
+                <tpAmb>1</tpAmb>
+                <finNFe>1</finNFe>
+                <indFinal>1</indFinal>
+                <indPres>1</indPres>
+                <procEmi>0</procEmi>
+                <verProc>1.0</verProc>
+            </ide>
+            <emit>
+                <CNPJ>22257735000138</CNPJ>
+                <xNome>Demo Emitente LTDA</xNome>
+                <xFant>Demo Co</xFant>
+                <enderEmit>
+                    <xLgr>Av. Demo</xLgr>
+                    <nro>100</nro>
+                    <xBairro>Centro</xBairro>
+                    <cMun>3550308</cMun>
+                    <xMun>São Paulo</xMun>
+                    <UF>SP</UF>
+                    <CEP>01000000</CEP>
+                    <cPais>1058</cPais>
+                    <xPais>BRASIL</xPais>
+                    <fone>1133334444</fone>
+                </enderEmit>
+                <IE>123456789012</IE>
+                <CRT>3</CRT>
+            </emit>
+            <dest>
+                <CNPJ>11222333000181</CNPJ>
+                <xNome>Demo Destinatário S/A</xNome>
+                <enderDest>
+                    <xLgr>Rua Cliente</xLgr>
+                    <nro>200</nro>
+                    <xBairro>Bairro Cliente</xBairro>
+                    <cMun>3550308</cMun>
+                    <xMun>São Paulo</xMun>
+                    <UF>SP</UF>
+                    <CEP>02000000</CEP>
+                    <cPais>1058</cPais>
+                    <xPais>BRASIL</xPais>
+                </enderDest>
+                <indIEDest>9</indIEDest>
+            </dest>
+            <det nItem="1">
+                <prod>
+                    <cProd>PROD-1</cProd>
+                    <cEAN>SEM GTIN</cEAN>
+                    <xProd>Item demo A — material de escritório</xProd>
+                    <NCM>49111090</NCM>
+                    <CFOP>5102</CFOP>
+                    <uCom>UN</uCom>
+                    <qCom>1.0000</qCom>
+                    <vUnCom>100.00</vUnCom>
+                    <vProd>100.00</vProd>
+                    <cEANTrib>SEM GTIN</cEANTrib>
+                    <uTrib>UN</uTrib>
+                    <qTrib>1.0000</qTrib>
+                    <vUnTrib>100.00</vUnTrib>
+                    <indTot>1</indTot>
+                </prod>
+                <imposto>
+                    <ICMS>
+                        <ICMS00>
+                            <orig>0</orig>
+                            <CST>00</CST>
+                            <modBC>3</modBC>
+                            <vBC>100.00</vBC>
+                            <pICMS>12.00</pICMS>
+                            <vICMS>12.00</vICMS>
+                        </ICMS00>
+                    </ICMS>
+                    <PIS>
+                        <PISAliq>
+                            <CST>01</CST>
+                            <vBC>100.00</vBC>
+                            <pPIS>1.65</pPIS>
+                            <vPIS>1.65</vPIS>
+                        </PISAliq>
+                    </PIS>
+                    <COFINS>
+                        <COFINSAliq>
+                            <CST>01</CST>
+                            <vBC>100.00</vBC>
+                            <pCOFINS>7.60</pCOFINS>
+                            <vCOFINS>7.60</vCOFINS>
+                        </COFINSAliq>
+                    </COFINS>
+                </imposto>
+                <infAdProd>Lote LT-1-2026 · Validade 12 meses · Origem: Brasil</infAdProd>
+            </det>
+            <det nItem="2">
+                <prod>
+                    <cProd>PROD-2</cProd>
+                    <cEAN>SEM GTIN</cEAN>
+                    <xProd>Item demo B — papelaria fina</xProd>
+                    <NCM>49111090</NCM>
+                    <CFOP>5102</CFOP>
+                    <uCom>UN</uCom>
+                    <qCom>1.0000</qCom>
+                    <vUnCom>100.00</vUnCom>
+                    <vProd>100.00</vProd>
+                    <cEANTrib>SEM GTIN</cEANTrib>
+                    <uTrib>UN</uTrib>
+                    <qTrib>1.0000</qTrib>
+                    <vUnTrib>100.00</vUnTrib>
+                    <indTot>1</indTot>
+                </prod>
+                <imposto>
+                    <ICMS>
+                        <ICMS00>
+                            <orig>0</orig>
+                            <CST>00</CST>
+                            <modBC>3</modBC>
+                            <vBC>100.00</vBC>
+                            <pICMS>12.00</pICMS>
+                            <vICMS>12.00</vICMS>
+                        </ICMS00>
+                    </ICMS>
+                    <PIS>
+                        <PISAliq>
+                            <CST>01</CST>
+                            <vBC>100.00</vBC>
+                            <pPIS>1.65</pPIS>
+                            <vPIS>1.65</vPIS>
+                        </PISAliq>
+                    </PIS>
+                    <COFINS>
+                        <COFINSAliq>
+                            <CST>01</CST>
+                            <vBC>100.00</vBC>
+                            <pCOFINS>7.60</pCOFINS>
+                            <vCOFINS>7.60</vCOFINS>
+                        </COFINSAliq>
+                    </COFINS>
+                </imposto>
+                <infAdProd>Lote LT-2-2026 · Validade 12 meses · Origem: Brasil</infAdProd>
+            </det>
+            <det nItem="3">
+                <prod>
+                    <cProd>PROD-3</cProd>
+                    <cEAN>SEM GTIN</cEAN>
+                    <xProd>Item demo C — suprimento gráfico</xProd>
+                    <NCM>49111090</NCM>
+                    <CFOP>5102</CFOP>
+                    <uCom>UN</uCom>
+                    <qCom>1.0000</qCom>
+                    <vUnCom>100.00</vUnCom>
+                    <vProd>100.00</vProd>
+                    <cEANTrib>SEM GTIN</cEANTrib>
+                    <uTrib>UN</uTrib>
+                    <qTrib>1.0000</qTrib>
+                    <vUnTrib>100.00</vUnTrib>
+                    <indTot>1</indTot>
+                </prod>
+                <imposto>
+                    <ICMS>
+                        <ICMS00>
+                            <orig>0</orig>
+                            <CST>00</CST>
+                            <modBC>3</modBC>
+                            <vBC>100.00</vBC>
+                            <pICMS>12.00</pICMS>
+                            <vICMS>12.00</vICMS>
+                        </ICMS00>
+                    </ICMS>
+                    <PIS>
+                        <PISAliq>
+                            <CST>01</CST>
+                            <vBC>100.00</vBC>
+                            <pPIS>1.65</pPIS>
+                            <vPIS>1.65</vPIS>
+                        </PISAliq>
+                    </PIS>
+                    <COFINS>
+                        <COFINSAliq>
+                            <CST>01</CST>
+                            <vBC>100.00</vBC>
+                            <pCOFINS>7.60</pCOFINS>
+                            <vCOFINS>7.60</vCOFINS>
+                        </COFINSAliq>
+                    </COFINS>
+                </imposto>
+                <infAdProd>Lote LT-3-2026 · Validade 12 meses · Origem: Brasil</infAdProd>
+            </det>
+            <det nItem="4">
+                <prod>
+                    <cProd>PROD-4</cProd>
+                    <cEAN>SEM GTIN</cEAN>
+                    <xProd>Item demo D — material para eventos</xProd>
+                    <NCM>49111090</NCM>
+                    <CFOP>5102</CFOP>
+                    <uCom>UN</uCom>
+                    <qCom>1.0000</qCom>
+                    <vUnCom>100.00</vUnCom>
+                    <vProd>100.00</vProd>
+                    <cEANTrib>SEM GTIN</cEANTrib>
+                    <uTrib>UN</uTrib>
+                    <qTrib>1.0000</qTrib>
+                    <vUnTrib>100.00</vUnTrib>
+                    <indTot>1</indTot>
+                </prod>
+                <imposto>
+                    <ICMS>
+                        <ICMS00>
+                            <orig>0</orig>
+                            <CST>00</CST>
+                            <modBC>3</modBC>
+                            <vBC>100.00</vBC>
+                            <pICMS>12.00</pICMS>
+                            <vICMS>12.00</vICMS>
+                        </ICMS00>
+                    </ICMS>
+                    <PIS>
+                        <PISAliq>
+                            <CST>01</CST>
+                            <vBC>100.00</vBC>
+                            <pPIS>1.65</pPIS>
+                            <vPIS>1.65</vPIS>
+                        </PISAliq>
+                    </PIS>
+                    <COFINS>
+                        <COFINSAliq>
+                            <CST>01</CST>
+                            <vBC>100.00</vBC>
+                            <pCOFINS>7.60</pCOFINS>
+                            <vCOFINS>7.60</vCOFINS>
+                        </COFINSAliq>
+                    </COFINS>
+                </imposto>
+                <infAdProd>Lote LT-4-2026 · Validade 12 meses · Origem: Brasil</infAdProd>
+            </det>
+            <det nItem="5">
+                <prod>
+                    <cProd>PROD-5</cProd>
+                    <cEAN>SEM GTIN</cEAN>
+                    <xProd>Item demo E — kit de apresentação</xProd>
+                    <NCM>49111090</NCM>
+                    <CFOP>5102</CFOP>
+                    <uCom>UN</uCom>
+                    <qCom>1.0000</qCom>
+                    <vUnCom>100.00</vUnCom>
+                    <vProd>100.00</vProd>
+                    <cEANTrib>SEM GTIN</cEANTrib>
+                    <uTrib>UN</uTrib>
+                    <qTrib>1.0000</qTrib>
+                    <vUnTrib>100.00</vUnTrib>
+                    <indTot>1</indTot>
+                </prod>
+                <imposto>
+                    <ICMS>
+                        <ICMS00>
+                            <orig>0</orig>
+                            <CST>00</CST>
+                            <modBC>3</modBC>
+                            <vBC>100.00</vBC>
+                            <pICMS>12.00</pICMS>
+                            <vICMS>12.00</vICMS>
+                        </ICMS00>
+                    </ICMS>
+                    <PIS>
+                        <PISAliq>
+                            <CST>01</CST>
+                            <vBC>100.00</vBC>
+                            <pPIS>1.65</pPIS>
+                            <vPIS>1.65</vPIS>
+                        </PISAliq>
+                    </PIS>
+                    <COFINS>
+                        <COFINSAliq>
+                            <CST>01</CST>
+                            <vBC>100.00</vBC>
+                            <pCOFINS>7.60</pCOFINS>
+                            <vCOFINS>7.60</vCOFINS>
+                        </COFINSAliq>
+                    </COFINS>
+                </imposto>
+                <infAdProd>Lote LT-5-2026 · Validade 12 meses · Origem: Brasil</infAdProd>
+            </det>
+            <det nItem="6">
+                <prod>
+                    <cProd>PROD-6</cProd>
+                    <cEAN>SEM GTIN</cEAN>
+                    <xProd>Item demo F — material institucional</xProd>
+                    <NCM>49111090</NCM>
+                    <CFOP>5102</CFOP>
+                    <uCom>UN</uCom>
+                    <qCom>1.0000</qCom>
+                    <vUnCom>100.00</vUnCom>
+                    <vProd>100.00</vProd>
+                    <cEANTrib>SEM GTIN</cEANTrib>
+                    <uTrib>UN</uTrib>
+                    <qTrib>1.0000</qTrib>
+                    <vUnTrib>100.00</vUnTrib>
+                    <indTot>1</indTot>
+                </prod>
+                <imposto>
+                    <ICMS>
+                        <ICMS00>
+                            <orig>0</orig>
+                            <CST>00</CST>
+                            <modBC>3</modBC>
+                            <vBC>100.00</vBC>
+                            <pICMS>12.00</pICMS>
+                            <vICMS>12.00</vICMS>
+                        </ICMS00>
+                    </ICMS>
+                    <PIS>
+                        <PISAliq>
+                            <CST>01</CST>
+                            <vBC>100.00</vBC>
+                            <pPIS>1.65</pPIS>
+                            <vPIS>1.65</vPIS>
+                        </PISAliq>
+                    </PIS>
+                    <COFINS>
+                        <COFINSAliq>
+                            <CST>01</CST>
+                            <vBC>100.00</vBC>
+                            <pCOFINS>7.60</pCOFINS>
+                            <vCOFINS>7.60</vCOFINS>
+                        </COFINSAliq>
+                    </COFINS>
+                </imposto>
+                <infAdProd>Lote LT-6-2026 · Validade 12 meses · Origem: Brasil</infAdProd>
+            </det>
+            <det nItem="7">
+                <prod>
+                    <cProd>PROD-7</cProd>
+                    <cEAN>SEM GTIN</cEAN>
+                    <xProd>Item demo G — embalagem premium</xProd>
+                    <NCM>49111090</NCM>
+                    <CFOP>5102</CFOP>
+                    <uCom>UN</uCom>
+                    <qCom>1.0000</qCom>
+                    <vUnCom>100.00</vUnCom>
+                    <vProd>100.00</vProd>
+                    <cEANTrib>SEM GTIN</cEANTrib>
+                    <uTrib>UN</uTrib>
+                    <qTrib>1.0000</qTrib>
+                    <vUnTrib>100.00</vUnTrib>
+                    <indTot>1</indTot>
+                </prod>
+                <imposto>
+                    <ICMS>
+                        <ICMS00>
+                            <orig>0</orig>
+                            <CST>00</CST>
+                            <modBC>3</modBC>
+                            <vBC>100.00</vBC>
+                            <pICMS>12.00</pICMS>
+                            <vICMS>12.00</vICMS>
+                        </ICMS00>
+                    </ICMS>
+                    <PIS>
+                        <PISAliq>
+                            <CST>01</CST>
+                            <vBC>100.00</vBC>
+                            <pPIS>1.65</pPIS>
+                            <vPIS>1.65</vPIS>
+                        </PISAliq>
+                    </PIS>
+                    <COFINS>
+                        <COFINSAliq>
+                            <CST>01</CST>
+                            <vBC>100.00</vBC>
+                            <pCOFINS>7.60</pCOFINS>
+                            <vCOFINS>7.60</vCOFINS>
+                        </COFINSAliq>
+                    </COFINS>
+                </imposto>
+                <infAdProd>Lote LT-7-2026 · Validade 12 meses · Origem: Brasil</infAdProd>
+            </det>
+            <det nItem="8">
+                <prod>
+                    <cProd>PROD-8</cProd>
+                    <cEAN>SEM GTIN</cEAN>
+                    <xProd>Item demo H — material de divulgação</xProd>
+                    <NCM>49111090</NCM>
+                    <CFOP>5102</CFOP>
+                    <uCom>UN</uCom>
+                    <qCom>1.0000</qCom>
+                    <vUnCom>100.00</vUnCom>
+                    <vProd>100.00</vProd>
+                    <cEANTrib>SEM GTIN</cEANTrib>
+                    <uTrib>UN</uTrib>
+                    <qTrib>1.0000</qTrib>
+                    <vUnTrib>100.00</vUnTrib>
+                    <indTot>1</indTot>
+                </prod>
+                <imposto>
+                    <ICMS>
+                        <ICMS00>
+                            <orig>0</orig>
+                            <CST>00</CST>
+                            <modBC>3</modBC>
+                            <vBC>100.00</vBC>
+                            <pICMS>12.00</pICMS>
+                            <vICMS>12.00</vICMS>
+                        </ICMS00>
+                    </ICMS>
+                    <PIS>
+                        <PISAliq>
+                            <CST>01</CST>
+                            <vBC>100.00</vBC>
+                            <pPIS>1.65</pPIS>
+                            <vPIS>1.65</vPIS>
+                        </PISAliq>
+                    </PIS>
+                    <COFINS>
+                        <COFINSAliq>
+                            <CST>01</CST>
+                            <vBC>100.00</vBC>
+                            <pCOFINS>7.60</pCOFINS>
+                            <vCOFINS>7.60</vCOFINS>
+                        </COFINSAliq>
+                    </COFINS>
+                </imposto>
+                <infAdProd>Lote LT-8-2026 · Validade 12 meses · Origem: Brasil</infAdProd>
+            </det>
+            <det nItem="9">
+                <prod>
+                    <cProd>PROD-9</cProd>
+                    <cEAN>SEM GTIN</cEAN>
+                    <xProd>Item demo I — kit corporativo</xProd>
+                    <NCM>49111090</NCM>
+                    <CFOP>5102</CFOP>
+                    <uCom>UN</uCom>
+                    <qCom>1.0000</qCom>
+                    <vUnCom>100.00</vUnCom>
+                    <vProd>100.00</vProd>
+                    <cEANTrib>SEM GTIN</cEANTrib>
+                    <uTrib>UN</uTrib>
+                    <qTrib>1.0000</qTrib>
+                    <vUnTrib>100.00</vUnTrib>
+                    <indTot>1</indTot>
+                </prod>
+                <imposto>
+                    <ICMS>
+                        <ICMS00>
+                            <orig>0</orig>
+                            <CST>00</CST>
+                            <modBC>3</modBC>
+                            <vBC>100.00</vBC>
+                            <pICMS>12.00</pICMS>
+                            <vICMS>12.00</vICMS>
+                        </ICMS00>
+                    </ICMS>
+                    <PIS>
+                        <PISAliq>
+                            <CST>01</CST>
+                            <vBC>100.00</vBC>
+                            <pPIS>1.65</pPIS>
+                            <vPIS>1.65</vPIS>
+                        </PISAliq>
+                    </PIS>
+                    <COFINS>
+                        <COFINSAliq>
+                            <CST>01</CST>
+                            <vBC>100.00</vBC>
+                            <pCOFINS>7.60</pCOFINS>
+                            <vCOFINS>7.60</vCOFINS>
+                        </COFINSAliq>
+                    </COFINS>
+                </imposto>
+                <infAdProd>Lote LT-9-2026 · Validade 12 meses · Origem: Brasil</infAdProd>
+            </det>
+            <det nItem="10">
+                <prod>
+                    <cProd>PROD-10</cProd>
+                    <cEAN>SEM GTIN</cEAN>
+                    <xProd>Item demo J — material expositor</xProd>
+                    <NCM>49111090</NCM>
+                    <CFOP>5102</CFOP>
+                    <uCom>UN</uCom>
+                    <qCom>1.0000</qCom>
+                    <vUnCom>100.00</vUnCom>
+                    <vProd>100.00</vProd>
+                    <cEANTrib>SEM GTIN</cEANTrib>
+                    <uTrib>UN</uTrib>
+                    <qTrib>1.0000</qTrib>
+                    <vUnTrib>100.00</vUnTrib>
+                    <indTot>1</indTot>
+                </prod>
+                <imposto>
+                    <ICMS>
+                        <ICMS00>
+                            <orig>0</orig>
+                            <CST>00</CST>
+                            <modBC>3</modBC>
+                            <vBC>100.00</vBC>
+                            <pICMS>12.00</pICMS>
+                            <vICMS>12.00</vICMS>
+                        </ICMS00>
+                    </ICMS>
+                    <PIS>
+                        <PISAliq>
+                            <CST>01</CST>
+                            <vBC>100.00</vBC>
+                            <pPIS>1.65</pPIS>
+                            <vPIS>1.65</vPIS>
+                        </PISAliq>
+                    </PIS>
+                    <COFINS>
+                        <COFINSAliq>
+                            <CST>01</CST>
+                            <vBC>100.00</vBC>
+                            <pCOFINS>7.60</pCOFINS>
+                            <vCOFINS>7.60</vCOFINS>
+                        </COFINSAliq>
+                    </COFINS>
+                </imposto>
+                <infAdProd>Lote LT-10-2026 · Validade 12 meses · Origem: Brasil</infAdProd>
+            </det>
+            <det nItem="11">
+                <prod>
+                    <cProd>PROD-11</cProd>
+                    <cEAN>SEM GTIN</cEAN>
+                    <xProd>Item demo K — brinde personalizado</xProd>
+                    <NCM>49111090</NCM>
+                    <CFOP>5102</CFOP>
+                    <uCom>UN</uCom>
+                    <qCom>1.0000</qCom>
+                    <vUnCom>100.00</vUnCom>
+                    <vProd>100.00</vProd>
+                    <cEANTrib>SEM GTIN</cEANTrib>
+                    <uTrib>UN</uTrib>
+                    <qTrib>1.0000</qTrib>
+                    <vUnTrib>100.00</vUnTrib>
+                    <indTot>1</indTot>
+                </prod>
+                <imposto>
+                    <ICMS>
+                        <ICMS00>
+                            <orig>0</orig>
+                            <CST>00</CST>
+                            <modBC>3</modBC>
+                            <vBC>100.00</vBC>
+                            <pICMS>12.00</pICMS>
+                            <vICMS>12.00</vICMS>
+                        </ICMS00>
+                    </ICMS>
+                    <PIS>
+                        <PISAliq>
+                            <CST>01</CST>
+                            <vBC>100.00</vBC>
+                            <pPIS>1.65</pPIS>
+                            <vPIS>1.65</vPIS>
+                        </PISAliq>
+                    </PIS>
+                    <COFINS>
+                        <COFINSAliq>
+                            <CST>01</CST>
+                            <vBC>100.00</vBC>
+                            <pCOFINS>7.60</pCOFINS>
+                            <vCOFINS>7.60</vCOFINS>
+                        </COFINSAliq>
+                    </COFINS>
+                </imposto>
+                <infAdProd>Lote LT-11-2026 · Validade 12 meses · Origem: Brasil</infAdProd>
+            </det>
+            <det nItem="12">
+                <prod>
+                    <cProd>PROD-12</cProd>
+                    <cEAN>SEM GTIN</cEAN>
+                    <xProd>Item demo L — material para feira</xProd>
+                    <NCM>49111090</NCM>
+                    <CFOP>5102</CFOP>
+                    <uCom>UN</uCom>
+                    <qCom>1.0000</qCom>
+                    <vUnCom>100.00</vUnCom>
+                    <vProd>100.00</vProd>
+                    <cEANTrib>SEM GTIN</cEANTrib>
+                    <uTrib>UN</uTrib>
+                    <qTrib>1.0000</qTrib>
+                    <vUnTrib>100.00</vUnTrib>
+                    <indTot>1</indTot>
+                </prod>
+                <imposto>
+                    <ICMS>
+                        <ICMS00>
+                            <orig>0</orig>
+                            <CST>00</CST>
+                            <modBC>3</modBC>
+                            <vBC>100.00</vBC>
+                            <pICMS>12.00</pICMS>
+                            <vICMS>12.00</vICMS>
+                        </ICMS00>
+                    </ICMS>
+                    <PIS>
+                        <PISAliq>
+                            <CST>01</CST>
+                            <vBC>100.00</vBC>
+                            <pPIS>1.65</pPIS>
+                            <vPIS>1.65</vPIS>
+                        </PISAliq>
+                    </PIS>
+                    <COFINS>
+                        <COFINSAliq>
+                            <CST>01</CST>
+                            <vBC>100.00</vBC>
+                            <pCOFINS>7.60</pCOFINS>
+                            <vCOFINS>7.60</vCOFINS>
+                        </COFINSAliq>
+                    </COFINS>
+                </imposto>
+                <infAdProd>Lote LT-12-2026 · Validade 12 meses · Origem: Brasil</infAdProd>
+            </det>
+            <det nItem="13">
+                <prod>
+                    <cProd>PROD-13</cProd>
+                    <cEAN>SEM GTIN</cEAN>
+                    <xProd>Item demo M — kit promocional</xProd>
+                    <NCM>49111090</NCM>
+                    <CFOP>5102</CFOP>
+                    <uCom>UN</uCom>
+                    <qCom>1.0000</qCom>
+                    <vUnCom>100.00</vUnCom>
+                    <vProd>100.00</vProd>
+                    <cEANTrib>SEM GTIN</cEANTrib>
+                    <uTrib>UN</uTrib>
+                    <qTrib>1.0000</qTrib>
+                    <vUnTrib>100.00</vUnTrib>
+                    <indTot>1</indTot>
+                </prod>
+                <imposto>
+                    <ICMS>
+                        <ICMS00>
+                            <orig>0</orig>
+                            <CST>00</CST>
+                            <modBC>3</modBC>
+                            <vBC>100.00</vBC>
+                            <pICMS>12.00</pICMS>
+                            <vICMS>12.00</vICMS>
+                        </ICMS00>
+                    </ICMS>
+                    <PIS>
+                        <PISAliq>
+                            <CST>01</CST>
+                            <vBC>100.00</vBC>
+                            <pPIS>1.65</pPIS>
+                            <vPIS>1.65</vPIS>
+                        </PISAliq>
+                    </PIS>
+                    <COFINS>
+                        <COFINSAliq>
+                            <CST>01</CST>
+                            <vBC>100.00</vBC>
+                            <pCOFINS>7.60</pCOFINS>
+                            <vCOFINS>7.60</vCOFINS>
+                        </COFINSAliq>
+                    </COFINS>
+                </imposto>
+                <infAdProd>Lote LT-13-2026 · Validade 12 meses · Origem: Brasil</infAdProd>
+            </det>
+            <det nItem="14">
+                <prod>
+                    <cProd>PROD-14</cProd>
+                    <cEAN>SEM GTIN</cEAN>
+                    <xProd>Item demo N — embalagem padrão</xProd>
+                    <NCM>49111090</NCM>
+                    <CFOP>5102</CFOP>
+                    <uCom>UN</uCom>
+                    <qCom>1.0000</qCom>
+                    <vUnCom>100.00</vUnCom>
+                    <vProd>100.00</vProd>
+                    <cEANTrib>SEM GTIN</cEANTrib>
+                    <uTrib>UN</uTrib>
+                    <qTrib>1.0000</qTrib>
+                    <vUnTrib>100.00</vUnTrib>
+                    <indTot>1</indTot>
+                </prod>
+                <imposto>
+                    <ICMS>
+                        <ICMS00>
+                            <orig>0</orig>
+                            <CST>00</CST>
+                            <modBC>3</modBC>
+                            <vBC>100.00</vBC>
+                            <pICMS>12.00</pICMS>
+                            <vICMS>12.00</vICMS>
+                        </ICMS00>
+                    </ICMS>
+                    <PIS>
+                        <PISAliq>
+                            <CST>01</CST>
+                            <vBC>100.00</vBC>
+                            <pPIS>1.65</pPIS>
+                            <vPIS>1.65</vPIS>
+                        </PISAliq>
+                    </PIS>
+                    <COFINS>
+                        <COFINSAliq>
+                            <CST>01</CST>
+                            <vBC>100.00</vBC>
+                            <pCOFINS>7.60</pCOFINS>
+                            <vCOFINS>7.60</vCOFINS>
+                        </COFINSAliq>
+                    </COFINS>
+                </imposto>
+                <infAdProd>Lote LT-14-2026 · Validade 12 meses · Origem: Brasil</infAdProd>
+            </det>
+            <det nItem="15">
+                <prod>
+                    <cProd>PROD-15</cProd>
+                    <cEAN>SEM GTIN</cEAN>
+                    <xProd>Item demo O — papel timbrado</xProd>
+                    <NCM>49111090</NCM>
+                    <CFOP>5102</CFOP>
+                    <uCom>UN</uCom>
+                    <qCom>1.0000</qCom>
+                    <vUnCom>100.00</vUnCom>
+                    <vProd>100.00</vProd>
+                    <cEANTrib>SEM GTIN</cEANTrib>
+                    <uTrib>UN</uTrib>
+                    <qTrib>1.0000</qTrib>
+                    <vUnTrib>100.00</vUnTrib>
+                    <indTot>1</indTot>
+                </prod>
+                <imposto>
+                    <ICMS>
+                        <ICMS00>
+                            <orig>0</orig>
+                            <CST>00</CST>
+                            <modBC>3</modBC>
+                            <vBC>100.00</vBC>
+                            <pICMS>12.00</pICMS>
+                            <vICMS>12.00</vICMS>
+                        </ICMS00>
+                    </ICMS>
+                    <PIS>
+                        <PISAliq>
+                            <CST>01</CST>
+                            <vBC>100.00</vBC>
+                            <pPIS>1.65</pPIS>
+                            <vPIS>1.65</vPIS>
+                        </PISAliq>
+                    </PIS>
+                    <COFINS>
+                        <COFINSAliq>
+                            <CST>01</CST>
+                            <vBC>100.00</vBC>
+                            <pCOFINS>7.60</pCOFINS>
+                            <vCOFINS>7.60</vCOFINS>
+                        </COFINSAliq>
+                    </COFINS>
+                </imposto>
+                <infAdProd>Lote LT-15-2026 · Validade 12 meses · Origem: Brasil</infAdProd>
+            </det>
+            <det nItem="16">
+                <prod>
+                    <cProd>PROD-16</cProd>
+                    <cEAN>SEM GTIN</cEAN>
+                    <xProd>Item demo P — material de campanha</xProd>
+                    <NCM>49111090</NCM>
+                    <CFOP>5102</CFOP>
+                    <uCom>UN</uCom>
+                    <qCom>1.0000</qCom>
+                    <vUnCom>100.00</vUnCom>
+                    <vProd>100.00</vProd>
+                    <cEANTrib>SEM GTIN</cEANTrib>
+                    <uTrib>UN</uTrib>
+                    <qTrib>1.0000</qTrib>
+                    <vUnTrib>100.00</vUnTrib>
+                    <indTot>1</indTot>
+                </prod>
+                <imposto>
+                    <ICMS>
+                        <ICMS00>
+                            <orig>0</orig>
+                            <CST>00</CST>
+                            <modBC>3</modBC>
+                            <vBC>100.00</vBC>
+                            <pICMS>12.00</pICMS>
+                            <vICMS>12.00</vICMS>
+                        </ICMS00>
+                    </ICMS>
+                    <PIS>
+                        <PISAliq>
+                            <CST>01</CST>
+                            <vBC>100.00</vBC>
+                            <pPIS>1.65</pPIS>
+                            <vPIS>1.65</vPIS>
+                        </PISAliq>
+                    </PIS>
+                    <COFINS>
+                        <COFINSAliq>
+                            <CST>01</CST>
+                            <vBC>100.00</vBC>
+                            <pCOFINS>7.60</pCOFINS>
+                            <vCOFINS>7.60</vCOFINS>
+                        </COFINSAliq>
+                    </COFINS>
+                </imposto>
+                <infAdProd>Lote LT-16-2026 · Validade 12 meses · Origem: Brasil</infAdProd>
+            </det>
+            <det nItem="17">
+                <prod>
+                    <cProd>PROD-17</cProd>
+                    <cEAN>SEM GTIN</cEAN>
+                    <xProd>Item demo Q — bobina térmica</xProd>
+                    <NCM>49111090</NCM>
+                    <CFOP>5102</CFOP>
+                    <uCom>UN</uCom>
+                    <qCom>1.0000</qCom>
+                    <vUnCom>100.00</vUnCom>
+                    <vProd>100.00</vProd>
+                    <cEANTrib>SEM GTIN</cEANTrib>
+                    <uTrib>UN</uTrib>
+                    <qTrib>1.0000</qTrib>
+                    <vUnTrib>100.00</vUnTrib>
+                    <indTot>1</indTot>
+                </prod>
+                <imposto>
+                    <ICMS>
+                        <ICMS00>
+                            <orig>0</orig>
+                            <CST>00</CST>
+                            <modBC>3</modBC>
+                            <vBC>100.00</vBC>
+                            <pICMS>12.00</pICMS>
+                            <vICMS>12.00</vICMS>
+                        </ICMS00>
+                    </ICMS>
+                    <PIS>
+                        <PISAliq>
+                            <CST>01</CST>
+                            <vBC>100.00</vBC>
+                            <pPIS>1.65</pPIS>
+                            <vPIS>1.65</vPIS>
+                        </PISAliq>
+                    </PIS>
+                    <COFINS>
+                        <COFINSAliq>
+                            <CST>01</CST>
+                            <vBC>100.00</vBC>
+                            <pCOFINS>7.60</pCOFINS>
+                            <vCOFINS>7.60</vCOFINS>
+                        </COFINSAliq>
+                    </COFINS>
+                </imposto>
+                <infAdProd>Lote LT-17-2026 · Validade 12 meses · Origem: Brasil</infAdProd>
+            </det>
+            <det nItem="18">
+                <prod>
+                    <cProd>PROD-18</cProd>
+                    <cEAN>SEM GTIN</cEAN>
+                    <xProd>Item demo R — bloco de notas</xProd>
+                    <NCM>49111090</NCM>
+                    <CFOP>5102</CFOP>
+                    <uCom>UN</uCom>
+                    <qCom>1.0000</qCom>
+                    <vUnCom>100.00</vUnCom>
+                    <vProd>100.00</vProd>
+                    <cEANTrib>SEM GTIN</cEANTrib>
+                    <uTrib>UN</uTrib>
+                    <qTrib>1.0000</qTrib>
+                    <vUnTrib>100.00</vUnTrib>
+                    <indTot>1</indTot>
+                </prod>
+                <imposto>
+                    <ICMS>
+                        <ICMS00>
+                            <orig>0</orig>
+                            <CST>00</CST>
+                            <modBC>3</modBC>
+                            <vBC>100.00</vBC>
+                            <pICMS>12.00</pICMS>
+                            <vICMS>12.00</vICMS>
+                        </ICMS00>
+                    </ICMS>
+                    <PIS>
+                        <PISAliq>
+                            <CST>01</CST>
+                            <vBC>100.00</vBC>
+                            <pPIS>1.65</pPIS>
+                            <vPIS>1.65</vPIS>
+                        </PISAliq>
+                    </PIS>
+                    <COFINS>
+                        <COFINSAliq>
+                            <CST>01</CST>
+                            <vBC>100.00</vBC>
+                            <pCOFINS>7.60</pCOFINS>
+                            <vCOFINS>7.60</vCOFINS>
+                        </COFINSAliq>
+                    </COFINS>
+                </imposto>
+                <infAdProd>Lote LT-18-2026 · Validade 12 meses · Origem: Brasil</infAdProd>
+            </det>
+            <det nItem="19">
+                <prod>
+                    <cProd>PROD-19</cProd>
+                    <cEAN>SEM GTIN</cEAN>
+                    <xProd>Item demo S — agenda corporativa</xProd>
+                    <NCM>49111090</NCM>
+                    <CFOP>5102</CFOP>
+                    <uCom>UN</uCom>
+                    <qCom>1.0000</qCom>
+                    <vUnCom>100.00</vUnCom>
+                    <vProd>100.00</vProd>
+                    <cEANTrib>SEM GTIN</cEANTrib>
+                    <uTrib>UN</uTrib>
+                    <qTrib>1.0000</qTrib>
+                    <vUnTrib>100.00</vUnTrib>
+                    <indTot>1</indTot>
+                </prod>
+                <imposto>
+                    <ICMS>
+                        <ICMS00>
+                            <orig>0</orig>
+                            <CST>00</CST>
+                            <modBC>3</modBC>
+                            <vBC>100.00</vBC>
+                            <pICMS>12.00</pICMS>
+                            <vICMS>12.00</vICMS>
+                        </ICMS00>
+                    </ICMS>
+                    <PIS>
+                        <PISAliq>
+                            <CST>01</CST>
+                            <vBC>100.00</vBC>
+                            <pPIS>1.65</pPIS>
+                            <vPIS>1.65</vPIS>
+                        </PISAliq>
+                    </PIS>
+                    <COFINS>
+                        <COFINSAliq>
+                            <CST>01</CST>
+                            <vBC>100.00</vBC>
+                            <pCOFINS>7.60</pCOFINS>
+                            <vCOFINS>7.60</vCOFINS>
+                        </COFINSAliq>
+                    </COFINS>
+                </imposto>
+                <infAdProd>Lote LT-19-2026 · Validade 12 meses · Origem: Brasil</infAdProd>
+            </det>
+            <det nItem="20">
+                <prod>
+                    <cProd>PROD-20</cProd>
+                    <cEAN>SEM GTIN</cEAN>
+                    <xProd>Item demo T — calendário 2026</xProd>
+                    <NCM>49111090</NCM>
+                    <CFOP>5102</CFOP>
+                    <uCom>UN</uCom>
+                    <qCom>1.0000</qCom>
+                    <vUnCom>100.00</vUnCom>
+                    <vProd>100.00</vProd>
+                    <cEANTrib>SEM GTIN</cEANTrib>
+                    <uTrib>UN</uTrib>
+                    <qTrib>1.0000</qTrib>
+                    <vUnTrib>100.00</vUnTrib>
+                    <indTot>1</indTot>
+                </prod>
+                <imposto>
+                    <ICMS>
+                        <ICMS00>
+                            <orig>0</orig>
+                            <CST>00</CST>
+                            <modBC>3</modBC>
+                            <vBC>100.00</vBC>
+                            <pICMS>12.00</pICMS>
+                            <vICMS>12.00</vICMS>
+                        </ICMS00>
+                    </ICMS>
+                    <PIS>
+                        <PISAliq>
+                            <CST>01</CST>
+                            <vBC>100.00</vBC>
+                            <pPIS>1.65</pPIS>
+                            <vPIS>1.65</vPIS>
+                        </PISAliq>
+                    </PIS>
+                    <COFINS>
+                        <COFINSAliq>
+                            <CST>01</CST>
+                            <vBC>100.00</vBC>
+                            <pCOFINS>7.60</pCOFINS>
+                            <vCOFINS>7.60</vCOFINS>
+                        </COFINSAliq>
+                    </COFINS>
+                </imposto>
+                <infAdProd>Lote LT-20-2026 · Validade 12 meses · Origem: Brasil</infAdProd>
+            </det>
+            <total>
+                <ICMSTot>
+                    <vBC>2000.00</vBC>
+                    <vICMS>240.00</vICMS>
+                    <vICMSDeson>0.00</vICMSDeson>
+                    <vFCP>0.00</vFCP>
+                    <vBCST>0.00</vBCST>
+                    <vST>0.00</vST>
+                    <vFCPST>0.00</vFCPST>
+                    <vFCPSTRet>0.00</vFCPSTRet>
+                    <vProd>2000.00</vProd>
+                    <vFrete>0.00</vFrete>
+                    <vSeg>0.00</vSeg>
+                    <vDesc>0.00</vDesc>
+                    <vII>0.00</vII>
+                    <vIPI>0.00</vIPI>
+                    <vIPIDevol>0.00</vIPIDevol>
+                    <vPIS>33.00</vPIS>
+                    <vCOFINS>152.00</vCOFINS>
+                    <vOutro>0.00</vOutro>
+                    <vNF>2000.00</vNF>
+                    <vTotTrib>0.00</vTotTrib>
+                </ICMSTot>
+            </total>
+            <transp>
+                <modFrete>9</modFrete>
+            </transp>
+            <cobr>
+                <fat>
+                    <nFat>300000001</nFat>
+                    <vOrig>2000.00</vOrig>
+                    <vDesc>0.00</vDesc>
+                    <vLiq>2000.04</vLiq>
+                </fat>
+                <dup>
+                    <nDup>001</nDup>
+                    <dVenc>2026-06-30</dVenc>
+                    <vDup>333.34</vDup>
+                </dup>                <dup>
+                    <nDup>002</nDup>
+                    <dVenc>2026-07-30</dVenc>
+                    <vDup>333.34</vDup>
+                </dup>                <dup>
+                    <nDup>003</nDup>
+                    <dVenc>2026-08-30</dVenc>
+                    <vDup>333.34</vDup>
+                </dup>                <dup>
+                    <nDup>004</nDup>
+                    <dVenc>2026-09-30</dVenc>
+                    <vDup>333.34</vDup>
+                </dup>                <dup>
+                    <nDup>005</nDup>
+                    <dVenc>2026-10-30</dVenc>
+                    <vDup>333.34</vDup>
+                </dup>                <dup>
+                    <nDup>006</nDup>
+                    <dVenc>2026-11-30</dVenc>
+                    <vDup>333.34</vDup>
+                </dup>
+            </cobr>
+            <pag>
+                <detPag>
+                    <tPag>17</tPag>
+                    <vPag>800.00</vPag>
+                </detPag>                <detPag>
+                    <tPag>03</tPag>
+                    <vPag>700.00</vPag>
+                </detPag>                <detPag>
+                    <tPag>99</tPag>
+                    <xPag>PROMOCIONAL BLACK FRIDAY</xPag>
+                    <vPag>500.00</vPag>
+                </detPag>
+            </pag>
+            <infAdic>
+                <infCpl>Fixture sintética gerada por generate-fixtures.sh para demo da PR #42.</infCpl>
+            </infAdic>
+        </infNFe>
+    </NFe>
+    <protNFe versao="4.00">
+        <infProt>
+            <tpAmb>1</tpAmb>
+            <verAplic>SP</verAplic>
+            <chNFe>35110501000000000000000000000000000000000000</chNFe>
+            <dhRecbto>2026-05-28T14:01:00-03:00</dhRecbto>
+            <nProt>135260000000000</nProt>
+            <digVal>aaa=</digVal>
+            <cStat>100</cStat>
+            <xMotivo>Autorizado o uso da NF-e</xMotivo>
+        </infProt>
+    </protNFe>
+</nfeProc>

--- a/DanfeSharp.Test/Xml/NFe/v4.00/v4_DanfeIntermediario.xml
+++ b/DanfeSharp.Test/Xml/NFe/v4.00/v4_DanfeIntermediario.xml
@@ -1,0 +1,365 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<nfeProc versao="4.00" xmlns="http://www.portalfiscal.inf.br/nfe">
+    <NFe xmlns="http://www.portalfiscal.inf.br/nfe">
+        <infNFe Id="NFe35110520000000000000000000000000000000000002" versao="4.00">
+            <ide>
+                <cUF>35</cUF>
+                <cNF>200000001</cNF>
+                <natOp>VENDA</natOp>
+                <mod>55</mod>
+                <serie>1</serie>
+                <nNF>200000001</nNF>
+                <dhEmi>2026-05-28T14:00:00-03:00</dhEmi>
+                <dhSaiEnt>2026-05-28T14:00:00-03:00</dhSaiEnt>
+                <tpNF>1</tpNF>
+                <idDest>1</idDest>
+                <cMunFG>3550308</cMunFG>
+                <tpImp>1</tpImp>
+                <tpEmis>1</tpEmis>
+                <cDV>1</cDV>
+                <tpAmb>1</tpAmb>
+                <finNFe>1</finNFe>
+                <indFinal>1</indFinal>
+                <indPres>1</indPres>
+                <procEmi>0</procEmi>
+                <verProc>1.0</verProc>
+            </ide>
+            <emit>
+                <CNPJ>22257735000138</CNPJ>
+                <xNome>Demo Emitente LTDA</xNome>
+                <xFant>Demo Co</xFant>
+                <enderEmit>
+                    <xLgr>Av. Demo</xLgr>
+                    <nro>100</nro>
+                    <xBairro>Centro</xBairro>
+                    <cMun>3550308</cMun>
+                    <xMun>São Paulo</xMun>
+                    <UF>SP</UF>
+                    <CEP>01000000</CEP>
+                    <cPais>1058</cPais>
+                    <xPais>BRASIL</xPais>
+                    <fone>1133334444</fone>
+                </enderEmit>
+                <IE>123456789012</IE>
+                <CRT>3</CRT>
+            </emit>
+            <dest>
+                <CNPJ>11222333000181</CNPJ>
+                <xNome>Demo Destinatário S/A</xNome>
+                <enderDest>
+                    <xLgr>Rua Cliente</xLgr>
+                    <nro>200</nro>
+                    <xBairro>Bairro Cliente</xBairro>
+                    <cMun>3550308</cMun>
+                    <xMun>São Paulo</xMun>
+                    <UF>SP</UF>
+                    <CEP>02000000</CEP>
+                    <cPais>1058</cPais>
+                    <xPais>BRASIL</xPais>
+                </enderDest>
+                <indIEDest>9</indIEDest>
+            </dest>
+            <det nItem="1">
+                <prod>
+                    <cProd>PROD-1</cProd>
+                    <cEAN>SEM GTIN</cEAN>
+                    <xProd>Notebook Demo Modelo X</xProd>
+                    <NCM>49111090</NCM>
+                    <CFOP>5102</CFOP>
+                    <uCom>UN</uCom>
+                    <qCom>1.0000</qCom>
+                    <vUnCom>300.00</vUnCom>
+                    <vProd>300.00</vProd>
+                    <cEANTrib>SEM GTIN</cEANTrib>
+                    <uTrib>UN</uTrib>
+                    <qTrib>1.0000</qTrib>
+                    <vUnTrib>300.00</vUnTrib>
+                    <indTot>1</indTot>
+                </prod>
+                <imposto>
+                    <ICMS>
+                        <ICMS00>
+                            <orig>0</orig>
+                            <CST>00</CST>
+                            <modBC>3</modBC>
+                            <vBC>300.00</vBC>
+                            <pICMS>12.00</pICMS>
+                            <vICMS>36.00</vICMS>
+                        </ICMS00>
+                    </ICMS>
+                    <PIS>
+                        <PISAliq>
+                            <CST>01</CST>
+                            <vBC>300.00</vBC>
+                            <pPIS>1.65</pPIS>
+                            <vPIS>4.95</vPIS>
+                        </PISAliq>
+                    </PIS>
+                    <COFINS>
+                        <COFINSAliq>
+                            <CST>01</CST>
+                            <vBC>300.00</vBC>
+                            <pCOFINS>7.60</pCOFINS>
+                            <vCOFINS>22.80</vCOFINS>
+                        </COFINSAliq>
+                    </COFINS>
+                </imposto>
+                <infAdProd>S/N: NB-001 · Garantia: 12 meses</infAdProd>
+            </det>
+            <det nItem="2">
+                <prod>
+                    <cProd>PROD-2</cProd>
+                    <cEAN>SEM GTIN</cEAN>
+                    <xProd>Mouse sem fio bluetooth</xProd>
+                    <NCM>49111090</NCM>
+                    <CFOP>5102</CFOP>
+                    <uCom>UN</uCom>
+                    <qCom>1.0000</qCom>
+                    <vUnCom>50.00</vUnCom>
+                    <vProd>50.00</vProd>
+                    <cEANTrib>SEM GTIN</cEANTrib>
+                    <uTrib>UN</uTrib>
+                    <qTrib>1.0000</qTrib>
+                    <vUnTrib>50.00</vUnTrib>
+                    <indTot>1</indTot>
+                </prod>
+                <imposto>
+                    <ICMS>
+                        <ICMS00>
+                            <orig>0</orig>
+                            <CST>00</CST>
+                            <modBC>3</modBC>
+                            <vBC>50.00</vBC>
+                            <pICMS>12.00</pICMS>
+                            <vICMS>6.00</vICMS>
+                        </ICMS00>
+                    </ICMS>
+                    <PIS>
+                        <PISAliq>
+                            <CST>01</CST>
+                            <vBC>50.00</vBC>
+                            <pPIS>1.65</pPIS>
+                            <vPIS>0.83</vPIS>
+                        </PISAliq>
+                    </PIS>
+                    <COFINS>
+                        <COFINSAliq>
+                            <CST>01</CST>
+                            <vBC>50.00</vBC>
+                            <pCOFINS>7.60</pCOFINS>
+                            <vCOFINS>3.80</vCOFINS>
+                        </COFINSAliq>
+                    </COFINS>
+                </imposto>
+            </det>
+            <det nItem="3">
+                <prod>
+                    <cProd>PROD-3</cProd>
+                    <cEAN>SEM GTIN</cEAN>
+                    <xProd>Teclado mecânico ABNT2</xProd>
+                    <NCM>49111090</NCM>
+                    <CFOP>5102</CFOP>
+                    <uCom>UN</uCom>
+                    <qCom>1.0000</qCom>
+                    <vUnCom>200.00</vUnCom>
+                    <vProd>200.00</vProd>
+                    <cEANTrib>SEM GTIN</cEANTrib>
+                    <uTrib>UN</uTrib>
+                    <qTrib>1.0000</qTrib>
+                    <vUnTrib>200.00</vUnTrib>
+                    <indTot>1</indTot>
+                </prod>
+                <imposto>
+                    <ICMS>
+                        <ICMS00>
+                            <orig>0</orig>
+                            <CST>00</CST>
+                            <modBC>3</modBC>
+                            <vBC>200.00</vBC>
+                            <pICMS>12.00</pICMS>
+                            <vICMS>24.00</vICMS>
+                        </ICMS00>
+                    </ICMS>
+                    <PIS>
+                        <PISAliq>
+                            <CST>01</CST>
+                            <vBC>200.00</vBC>
+                            <pPIS>1.65</pPIS>
+                            <vPIS>3.30</vPIS>
+                        </PISAliq>
+                    </PIS>
+                    <COFINS>
+                        <COFINSAliq>
+                            <CST>01</CST>
+                            <vBC>200.00</vBC>
+                            <pCOFINS>7.60</pCOFINS>
+                            <vCOFINS>15.20</vCOFINS>
+                        </COFINSAliq>
+                    </COFINS>
+                </imposto>
+                <infAdProd>Switch: Cherry MX Brown · Layout: ABNT2</infAdProd>
+            </det>
+            <det nItem="4">
+                <prod>
+                    <cProd>PROD-4</cProd>
+                    <cEAN>SEM GTIN</cEAN>
+                    <xProd>Cabo USB-C 1m</xProd>
+                    <NCM>49111090</NCM>
+                    <CFOP>5102</CFOP>
+                    <uCom>UN</uCom>
+                    <qCom>1.0000</qCom>
+                    <vUnCom>30.00</vUnCom>
+                    <vProd>30.00</vProd>
+                    <cEANTrib>SEM GTIN</cEANTrib>
+                    <uTrib>UN</uTrib>
+                    <qTrib>1.0000</qTrib>
+                    <vUnTrib>30.00</vUnTrib>
+                    <indTot>1</indTot>
+                </prod>
+                <imposto>
+                    <ICMS>
+                        <ICMS00>
+                            <orig>0</orig>
+                            <CST>00</CST>
+                            <modBC>3</modBC>
+                            <vBC>30.00</vBC>
+                            <pICMS>12.00</pICMS>
+                            <vICMS>3.60</vICMS>
+                        </ICMS00>
+                    </ICMS>
+                    <PIS>
+                        <PISAliq>
+                            <CST>01</CST>
+                            <vBC>30.00</vBC>
+                            <pPIS>1.65</pPIS>
+                            <vPIS>0.49</vPIS>
+                        </PISAliq>
+                    </PIS>
+                    <COFINS>
+                        <COFINSAliq>
+                            <CST>01</CST>
+                            <vBC>30.00</vBC>
+                            <pCOFINS>7.60</pCOFINS>
+                            <vCOFINS>2.28</vCOFINS>
+                        </COFINSAliq>
+                    </COFINS>
+                </imposto>
+            </det>
+            <det nItem="5">
+                <prod>
+                    <cProd>PROD-5</cProd>
+                    <cEAN>SEM GTIN</cEAN>
+                    <xProd>Monitor 24 polegadas</xProd>
+                    <NCM>49111090</NCM>
+                    <CFOP>5102</CFOP>
+                    <uCom>UN</uCom>
+                    <qCom>1.0000</qCom>
+                    <vUnCom>420.00</vUnCom>
+                    <vProd>420.00</vProd>
+                    <cEANTrib>SEM GTIN</cEANTrib>
+                    <uTrib>UN</uTrib>
+                    <qTrib>1.0000</qTrib>
+                    <vUnTrib>420.00</vUnTrib>
+                    <indTot>1</indTot>
+                </prod>
+                <imposto>
+                    <ICMS>
+                        <ICMS00>
+                            <orig>0</orig>
+                            <CST>00</CST>
+                            <modBC>3</modBC>
+                            <vBC>420.00</vBC>
+                            <pICMS>12.00</pICMS>
+                            <vICMS>50.40</vICMS>
+                        </ICMS00>
+                    </ICMS>
+                    <PIS>
+                        <PISAliq>
+                            <CST>01</CST>
+                            <vBC>420.00</vBC>
+                            <pPIS>1.65</pPIS>
+                            <vPIS>6.93</vPIS>
+                        </PISAliq>
+                    </PIS>
+                    <COFINS>
+                        <COFINSAliq>
+                            <CST>01</CST>
+                            <vBC>420.00</vBC>
+                            <pCOFINS>7.60</pCOFINS>
+                            <vCOFINS>31.92</vCOFINS>
+                        </COFINSAliq>
+                    </COFINS>
+                </imposto>
+                <infAdProd>Resolução: 1920x1080 · 75Hz · Modelo: MN-24FHD</infAdProd>
+            </det>
+            <total>
+                <ICMSTot>
+                    <vBC>1000.00</vBC>
+                    <vICMS>120.00</vICMS>
+                    <vICMSDeson>0.00</vICMSDeson>
+                    <vFCP>0.00</vFCP>
+                    <vBCST>0.00</vBCST>
+                    <vST>0.00</vST>
+                    <vFCPST>0.00</vFCPST>
+                    <vFCPSTRet>0.00</vFCPSTRet>
+                    <vProd>1000.00</vProd>
+                    <vFrete>0.00</vFrete>
+                    <vSeg>0.00</vSeg>
+                    <vDesc>0.00</vDesc>
+                    <vII>0.00</vII>
+                    <vIPI>0.00</vIPI>
+                    <vIPIDevol>0.00</vIPIDevol>
+                    <vPIS>16.50</vPIS>
+                    <vCOFINS>76.00</vCOFINS>
+                    <vOutro>0.00</vOutro>
+                    <vNF>1000.00</vNF>
+                    <vTotTrib>0.00</vTotTrib>
+                </ICMSTot>
+            </total>
+            <transp>
+                <modFrete>9</modFrete>
+            </transp>
+            <cobr>
+                <fat>
+                    <nFat>200000001</nFat>
+                    <vOrig>1000.00</vOrig>
+                    <vDesc>0.00</vDesc>
+                    <vLiq>1000.00</vLiq>
+                </fat>
+                <dup>
+                    <nDup>001</nDup>
+                    <dVenc>2026-06-28</dVenc>
+                    <vDup>500.00</vDup>
+                </dup>                <dup>
+                    <nDup>002</nDup>
+                    <dVenc>2026-07-28</dVenc>
+                    <vDup>500.00</vDup>
+                </dup>
+            </cobr>
+            <pag>
+                <detPag>
+                    <tPag>03</tPag>
+                    <vPag>600.00</vPag>
+                </detPag>                <detPag>
+                    <tPag>17</tPag>
+                    <vPag>400.00</vPag>
+                </detPag>
+            </pag>
+            <infAdic>
+                <infCpl>Fixture sintética gerada por generate-fixtures.sh para demo da PR #42.</infCpl>
+            </infAdic>
+        </infNFe>
+    </NFe>
+    <protNFe versao="4.00">
+        <infProt>
+            <tpAmb>1</tpAmb>
+            <verAplic>SP</verAplic>
+            <chNFe>35110501000000000000000000000000000000000000</chNFe>
+            <dhRecbto>2026-05-28T14:01:00-03:00</dhRecbto>
+            <nProt>135260000000000</nProt>
+            <digVal>aaa=</digVal>
+            <cStat>100</cStat>
+            <xMotivo>Autorizado o uso da NF-e</xMotivo>
+        </infProt>
+    </protNFe>
+</nfeProc>

--- a/DanfeSharp.Test/Xml/NFe/v4.00/v4_DanfeMinimo.xml
+++ b/DanfeSharp.Test/Xml/NFe/v4.00/v4_DanfeMinimo.xml
@@ -1,0 +1,152 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<nfeProc versao="4.00" xmlns="http://www.portalfiscal.inf.br/nfe">
+    <NFe xmlns="http://www.portalfiscal.inf.br/nfe">
+        <infNFe Id="NFe35110510000000000000000000000000000000000001" versao="4.00">
+            <ide>
+                <cUF>35</cUF>
+                <cNF>100000001</cNF>
+                <natOp>VENDA</natOp>
+                <mod>55</mod>
+                <serie>1</serie>
+                <nNF>100000001</nNF>
+                <dhEmi>2026-05-28T14:00:00-03:00</dhEmi>
+                <dhSaiEnt>2026-05-28T14:00:00-03:00</dhSaiEnt>
+                <tpNF>1</tpNF>
+                <idDest>1</idDest>
+                <cMunFG>3550308</cMunFG>
+                <tpImp>1</tpImp>
+                <tpEmis>1</tpEmis>
+                <cDV>1</cDV>
+                <tpAmb>1</tpAmb>
+                <finNFe>1</finNFe>
+                <indFinal>1</indFinal>
+                <indPres>1</indPres>
+                <procEmi>0</procEmi>
+                <verProc>1.0</verProc>
+            </ide>
+            <emit>
+                <CNPJ>22257735000138</CNPJ>
+                <xNome>Demo Emitente LTDA</xNome>
+                <xFant>Demo Co</xFant>
+                <enderEmit>
+                    <xLgr>Av. Demo</xLgr>
+                    <nro>100</nro>
+                    <xBairro>Centro</xBairro>
+                    <cMun>3550308</cMun>
+                    <xMun>São Paulo</xMun>
+                    <UF>SP</UF>
+                    <CEP>01000000</CEP>
+                    <cPais>1058</cPais>
+                    <xPais>BRASIL</xPais>
+                    <fone>1133334444</fone>
+                </enderEmit>
+                <IE>123456789012</IE>
+                <CRT>3</CRT>
+            </emit>
+            <dest>
+                <CNPJ>11222333000181</CNPJ>
+                <xNome>Demo Destinatário S/A</xNome>
+                <enderDest>
+                    <xLgr>Rua Cliente</xLgr>
+                    <nro>200</nro>
+                    <xBairro>Bairro Cliente</xBairro>
+                    <cMun>3550308</cMun>
+                    <xMun>São Paulo</xMun>
+                    <UF>SP</UF>
+                    <CEP>02000000</CEP>
+                    <cPais>1058</cPais>
+                    <xPais>BRASIL</xPais>
+                </enderDest>
+                <indIEDest>9</indIEDest>
+            </dest>
+            <det nItem="1">
+                <prod>
+                    <cProd>PROD-1</cProd>
+                    <cEAN>SEM GTIN</cEAN>
+                    <xProd>Caneta esferográfica azul</xProd>
+                    <NCM>49111090</NCM>
+                    <CFOP>5102</CFOP>
+                    <uCom>UN</uCom>
+                    <qCom>1.0000</qCom>
+                    <vUnCom>50.00</vUnCom>
+                    <vProd>50.00</vProd>
+                    <cEANTrib>SEM GTIN</cEANTrib>
+                    <uTrib>UN</uTrib>
+                    <qTrib>1.0000</qTrib>
+                    <vUnTrib>50.00</vUnTrib>
+                    <indTot>1</indTot>
+                </prod>
+                <imposto>
+                    <ICMS>
+                        <ICMS00>
+                            <orig>0</orig>
+                            <CST>00</CST>
+                            <modBC>3</modBC>
+                            <vBC>50.00</vBC>
+                            <pICMS>12.00</pICMS>
+                            <vICMS>6.00</vICMS>
+                        </ICMS00>
+                    </ICMS>
+                    <PIS>
+                        <PISAliq>
+                            <CST>01</CST>
+                            <vBC>50.00</vBC>
+                            <pPIS>1.65</pPIS>
+                            <vPIS>0.83</vPIS>
+                        </PISAliq>
+                    </PIS>
+                    <COFINS>
+                        <COFINSAliq>
+                            <CST>01</CST>
+                            <vBC>50.00</vBC>
+                            <pCOFINS>7.60</pCOFINS>
+                            <vCOFINS>3.80</vCOFINS>
+                        </COFINSAliq>
+                    </COFINS>
+                </imposto>
+            </det>
+            <total>
+                <ICMSTot>
+                    <vBC>50.00</vBC>
+                    <vICMS>6.00</vICMS>
+                    <vICMSDeson>0.00</vICMSDeson>
+                    <vFCP>0.00</vFCP>
+                    <vBCST>0.00</vBCST>
+                    <vST>0.00</vST>
+                    <vFCPST>0.00</vFCPST>
+                    <vFCPSTRet>0.00</vFCPSTRet>
+                    <vProd>50.00</vProd>
+                    <vFrete>0.00</vFrete>
+                    <vSeg>0.00</vSeg>
+                    <vDesc>0.00</vDesc>
+                    <vII>0.00</vII>
+                    <vIPI>0.00</vIPI>
+                    <vIPIDevol>0.00</vIPIDevol>
+                    <vPIS>0.83</vPIS>
+                    <vCOFINS>3.80</vCOFINS>
+                    <vOutro>0.00</vOutro>
+                    <vNF>50.00</vNF>
+                    <vTotTrib>0.00</vTotTrib>
+                </ICMSTot>
+            </total>
+            <transp>
+                <modFrete>9</modFrete>
+            </transp>
+            <infAdic>
+                <infCpl>Fixture sintética gerada por generate-fixtures.sh para demo da PR #42.</infCpl>
+            </infAdic>
+        </infNFe>
+    </NFe>
+    <protNFe versao="4.00">
+        <infProt>
+            <tpAmb>1</tpAmb>
+            <verAplic>SP</verAplic>
+            <chNFe>35110501000000000000000000000000000000000000</chNFe>
+            <dhRecbto>2026-05-28T14:01:00-03:00</dhRecbto>
+            <nProt>135260000000000</nProt>
+            <digVal>aaa=</digVal>
+            <cStat>100</cStat>
+            <xMotivo>Autorizado o uso da NF-e</xMotivo>
+        </infProt>
+    </protNFe>
+</nfeProc>

--- a/DanfeSharp.Test/Xml/NFe/v4.00/v4_RevendaMaisDemo.xml
+++ b/DanfeSharp.Test/Xml/NFe/v4.00/v4_RevendaMaisDemo.xml
@@ -1,0 +1,327 @@
+<nfeProc versao="4.00" xmlns="http://www.portalfiscal.inf.br/nfe">
+    <NFe xmlns="http://www.portalfiscal.inf.br/nfe">
+        <infNFe Id="NFe35110264542918000145553392048039911837511733" versao="4.00">
+            <ide>
+                <cUF>32</cUF>
+                <cNF>11105904</cNF>
+                <natOp>VENDA / LICENCA DE USO /</natOp>
+                <mod>55</mod>
+                <serie>339</serie>
+                <nNF>204803991</nNF>
+                <dhEmi>2018-09-11T10:59:04-03:00</dhEmi>
+                <dhSaiEnt>2018-09-11T10:59:04-03:00</dhSaiEnt>
+                <tpNF>1</tpNF>
+                <idDest>2</idDest>
+                <cMunFG>3550308</cMunFG>
+                <tpImp>1</tpImp>
+                <tpEmis>1</tpEmis>
+                <cDV>5</cDV>
+                <tpAmb>1</tpAmb>
+                <finNFe>1</finNFe>
+                <indFinal>1</indFinal>
+                <indPres>9</indPres>
+                <procEmi>0</procEmi>
+                <verProc>1</verProc>
+            </ide>
+            <emit>
+                <CNPJ>64542918000145</CNPJ>
+                <xNome>Cyberdyne Systems Corp.</xNome>
+                <xFant>Cyberdyne</xFant>
+                <enderEmit>
+                    <xLgr>Rua Deputado Carlos Correia</xLgr>
+                    <nro>307</nro>
+                    <xCpl>Glp:2 EUV:Sala:12CIVIT II</xCpl>
+                    <xBairro>Siqueira Campos</xBairro>
+                    <cMun>3550308</cMun>
+                    <xMun>SERRA</xMun>
+                    <UF>ES</UF>
+                    <CEP>49075976</CEP>
+                    <cPais>1058</cPais>
+                    <xPais>BRASIL</xPais>
+                    <fone>0112345678</fone>
+                </enderEmit>
+                <IE>270913586892</IE>
+                <IEST>270913586892</IEST>
+                <IM>4.11111-7</IM>
+                <CNAE>4742300</CNAE>
+                <CRT>3</CRT>
+            </emit>
+            <dest>
+                <CNPJ>22257735000138</CNPJ>
+                <xNome>Umbrella Corp</xNome>
+                <enderDest>
+                    <xLgr>Rua João Augusto Morais</xLgr>
+                    <nro>S/N</nro>
+                    <xBairro>7 DISTRITO</xBairro>
+                    <cMun>3550308</cMun>
+                    <xMun>São Paulo</xMun>
+                    <UF>SP</UF>
+                    <CEP>08010150</CEP>
+                    <cPais>1058</cPais>
+                    <xPais>BRASIL</xPais>
+                </enderDest>
+                <indIEDest>1</indIEDest>
+                <IE>361499373647</IE>
+            </dest>
+            <entrega>
+			    <CNPJ>22257735000138</CNPJ>
+				<xNome>Oceanic Airlines</xNome>
+                <xLgr>End Entrega</xLgr>
+                <nro>N Entrega</nro>
+                <xBairro>5 DISTRITO</xBairro>
+                <cMun>3550308</cMun>
+                <xMun>São Paulo</xMun>
+				<UF>SP</UF>
+				<CEP>08010150</CEP>
+				<fone>1012345678</fone>
+				<IE>361499373647</IE>
+            </entrega>
+            <det nItem="1">
+                <prod>
+                    <cProd>LC</cProd>
+                    <cEAN>889842132892</cEAN>
+                    <xProd>PN:T5D-02932  -- SOFTWARE A</xProd>
+                    <NCM>49111090</NCM>
+                    <CEST>0000000</CEST>
+                    <indEscala>S</indEscala>
+                    <CFOP>6102</CFOP>
+                    <uCom>un</uCom>
+                    <qCom>1.0000</qCom>
+                    <vUnCom>10.82</vUnCom>
+                    <vProd>10.82</vProd>
+                    <cEANTrib>0889842132892</cEANTrib>
+                    <uTrib>un</uTrib>
+                    <qTrib>1.0000</qTrib>
+                    <vUnTrib>10.82</vUnTrib>
+                    <indTot>1</indTot>
+                    <xPed>10775</xPed>
+                    <nItemPed>0</nItemPed>
+                </prod>
+                <imposto>
+                    <ICMS>
+                        <ICMS00>
+                            <orig>4</orig>
+                            <CST>00</CST>
+                            <modBC>3</modBC>
+                            <vBC>10.82</vBC>
+                            <pICMS>12.00</pICMS>
+                            <vICMS>1.30</vICMS>
+                        </ICMS00>
+                    </ICMS>
+                    <PIS>
+                        <PISAliq>
+                            <CST>01</CST>
+                            <vBC>10.82</vBC>
+                            <pPIS>1.65</pPIS>
+                            <vPIS>0.18</vPIS>
+                        </PISAliq>
+                    </PIS>
+                    <COFINS>
+                        <COFINSAliq>
+                            <CST>01</CST>
+                            <vBC>10.82</vBC>
+                            <pCOFINS>7.60</pCOFINS>
+                            <vCOFINS>0.82</vCOFINS>
+                        </COFINSAliq>
+                    </COFINS>
+                </imposto>
+                <infAdProd>Licença digital · Não-reembolsável · S/N: ABC123-VERSAO-3.0</infAdProd>
+            </det>
+            <det nItem="2">
+                <prod>
+                    <cProd>LCOM144514B</cProd>
+                    <cEAN>SEM GTIN</cEAN>
+                    <xProd>PN:T5D-02932LIC  -- SOFTWARE B</xProd>
+                    <NCM>00</NCM>
+                    <CEST>0000000</CEST>
+                    <indEscala>S</indEscala>
+                    <CFOP>6933</CFOP>
+                    <uCom>un</uCom>
+                    <qCom>1.0000</qCom>
+                    <vUnCom>936.18</vUnCom>
+                    <vProd>936.18</vProd>
+                    <cEANTrib>SEM GTIN</cEANTrib>
+                    <uTrib>un</uTrib>
+                    <qTrib>1.0000</qTrib>
+                    <vUnTrib>936.18</vUnTrib>
+                    <indTot>1</indTot>
+                    <xPed>10775</xPed>
+                    <nItemPed>0</nItemPed>
+                </prod>
+                <imposto>
+                    <ISSQN>
+                        <vBC>936.18</vBC>
+                        <vAliq>3.00</vAliq>
+                        <vISSQN>28.09</vISSQN>
+                        <cMunFG>3550308</cMunFG>
+                        <cListServ>01.05</cListServ>
+                        <indISS>1</indISS>
+                        <indIncentivo>2</indIncentivo>
+                    </ISSQN>
+                    <PIS>
+                        <PISAliq>
+                            <CST>01</CST>
+                            <vBC>936.18</vBC>
+                            <pPIS>1.65</pPIS>
+                            <vPIS>15.45</vPIS>
+                        </PISAliq>
+                    </PIS>
+                    <COFINS>
+                        <COFINSAliq>
+                            <CST>01</CST>
+                            <vBC>936.18</vBC>
+                            <pCOFINS>7.60</pCOFINS>
+                            <vCOFINS>71.15</vCOFINS>
+                        </COFINSAliq>
+                    </COFINS>
+                </imposto>
+                <infAdProd>Garantia: 12 meses contra defeitos de fabricação · Suporte: 0800-XXX-YYYY</infAdProd>
+            </det>
+            <total>
+                <ICMSTot>
+                    <vBC>3040.82</vBC>
+                    <vICMS>360.05</vICMS>
+                    <vICMSDeson>0.00</vICMSDeson>
+                    <vICMSUFDest>0.00</vICMSUFDest>
+                    <vICMSUFRemet>0.00</vICMSUFRemet>
+                    <vFCP>0</vFCP>
+                    <vBCST>0.00</vBCST>
+                    <vST>0.00</vST>
+                    <vFCPST>0</vFCPST>
+                    <vFCPSTRet>0</vFCPSTRet>
+                    <vProd>3040.82</vProd>
+                    <vFrete>0.00</vFrete>
+                    <vSeg>0.00</vSeg>
+                    <vDesc>0.00</vDesc>
+                    <vII>0.00</vII>
+                    <vIPI>0.00</vIPI>
+                    <vIPIDevol>0</vIPIDevol>
+                    <vPIS>50.17</vPIS>
+                    <vCOFINS>231.10</vCOFINS>
+                    <vOutro>0.00</vOutro>
+                    <vNF>3977.00</vNF>
+                    <vTotTrib>0.00</vTotTrib>
+                </ICMSTot>
+                <ISSQNtot>
+                    <vServ>936.18</vServ>
+                    <vBC>936.18</vBC>
+                    <vISS>28.09</vISS>
+                    <vPIS>15.45</vPIS>
+                    <vCOFINS>71.15</vCOFINS>
+                    <dCompet>2018-10-11</dCompet>
+                </ISSQNtot>
+            </total>
+            <transp>
+                <modFrete>0</modFrete>
+                <transporta>
+                    <CNPJ>23451995000102</CNPJ>
+                    <xNome>Oceanic Airlines</xNome>
+                    <IE>678084138533</IE>
+                    <xEnder>Estrada do Acampamento, 773</xEnder>
+                    <xMun>São Bernardo do Campo</xMun>
+                    <UF>SP</UF>
+                </transporta>
+                <vol>
+                    <qVol>2</qVol>
+                    <pesoL>2.380</pesoL>
+                    <pesoB>3.000</pesoB>
+                </vol>
+            </transp>
+            <cobr>
+                <fat>
+                    <nFat>800178201</nFat>
+                    <vOrig>3977.00</vOrig>
+                    <vDesc>0.00</vDesc>
+                    <vLiq>3977.00</vLiq>
+                </fat>
+                <dup>
+                    <nDup>001</nDup>
+                    <dVenc>2026-06-15</dVenc>
+                    <vDup>662.83</vDup>
+                </dup>
+                <dup>
+                    <nDup>002</nDup>
+                    <dVenc>2026-07-15</dVenc>
+                    <vDup>662.83</vDup>
+                </dup>
+                <dup>
+                    <nDup>003</nDup>
+                    <dVenc>2026-08-15</dVenc>
+                    <vDup>662.83</vDup>
+                </dup>
+                <dup>
+                    <nDup>004</nDup>
+                    <dVenc>2026-09-15</dVenc>
+                    <vDup>662.83</vDup>
+                </dup>
+                <dup>
+                    <nDup>005</nDup>
+                    <dVenc>2026-10-15</dVenc>
+                    <vDup>662.83</vDup>
+                </dup>
+                <dup>
+                    <nDup>006</nDup>
+                    <dVenc>2026-11-15</dVenc>
+                    <vDup>662.85</vDup>
+                </dup>
+            </cobr>
+            <pag>
+                <detPag>
+                    <tPag>17</tPag>
+                    <vPag>1500.00</vPag>
+                </detPag>
+                <detPag>
+                    <tPag>03</tPag>
+                    <vPag>1000.00</vPag>
+                    <card>
+                        <tpIntegra>1</tpIntegra>
+                        <CNPJ>01027058000191</CNPJ>
+                        <tBand>02</tBand>
+                        <cAut>123456</cAut>
+                    </card>
+                </detPag>
+                <detPag>
+                    <tPag>99</tPag>
+                    <xPag>VALE TROCO</xPag>
+                    <vPag>1477.00</vPag>
+                </detPag>
+                <vTroco>0.00</vTroco>
+            </pag>
+            <infAdic>
+                <infCpl>Praca para Pagamento: Sao Paulo - SP</infCpl>
+            </infAdic>
+        </infNFe>
+        <Signature xmlns="http://www.w3.org/2000/09/xmldsig#">
+            <SignedInfo>
+                <CanonicalizationMethod Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315" />
+                <SignatureMethod Algorithm="http://www.w3.org/2000/09/xmldsig#rsa-sha1" />
+                <Reference URI="#NFe35110264542918000145553392048039911837511733">
+                    <Transforms>
+                        <Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature" />
+                        <Transform Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315" />
+                    </Transforms>
+                    <DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1" />
+                    <DigestValue>RGFuZmVTaGFycA==</DigestValue>
+                </Reference>
+            </SignedInfo>
+            <SignatureValue>RGFuZmVTaGFycA==</SignatureValue>
+            <KeyInfo>
+                <X509Data>
+                    <X509Certificate>RGFuZmVTaGFycA==</X509Certificate>
+                </X509Data>
+            </KeyInfo>
+        </Signature>
+    </NFe>
+    <protNFe versao="4.00" xmlns="http://www.portalfiscal.inf.br/nfe">
+        <infProt>
+            <tpAmb>1</tpAmb>
+            <verAplic>SVRS201809031520</verAplic>
+            <chNFe>35110264542918000145553392048039911837511733</chNFe>
+            <dhRecbto>2018-09-11T10:59:21-03:00</dhRecbto>
+            <nProt>332181142495375</nProt>
+            <digVal>RGFuZmVTaGFycA==</digVal>
+            <cStat>100</cStat>
+            <xMotivo>Autorizado o uso da NF-e</xMotivo>
+        </infProt>
+    </protNFe>
+</nfeProc>

--- a/DanfeSharp/Blocos/BlocoDuplicataFatura.cs
+++ b/DanfeSharp/Blocos/BlocoDuplicataFatura.cs
@@ -11,7 +11,11 @@ namespace DanfeSharp.Blocos
             var de = viewModel.Duplicatas.Select(x => new Duplicata (estilo, x)).ToList();
             var eh = de.First().Height;
 
-            int numeroElementosLinha = ViewModel.IsPaisagem ? 7 : 6;
+            // Reduzido de 6→3 (retrato) e 7→4 (paisagem) para acomodar o
+            // layout horizontal dos 3 campos (Número/Vencimento/Valor) dentro
+            // de cada Duplicata — sem isso os valores ficariam cortados em
+            // colunas estreitas. Ver Duplicata.cs:Draw.
+            int numeroElementosLinha = ViewModel.IsPaisagem ? 4 : 3;
             int i = 0;
 
             while (i < de.Count) 
@@ -24,8 +28,13 @@ namespace DanfeSharp.Blocos
                     fl.ComElemento (de[i]);
                 }
 
+                // Preenche o resto da linha com celulas vazias (apenas borda)
+                // para que o quadro va ate a margem direita mesmo quando o
+                // numero de duplicatas nao e multiplo de numeroElementosLinha
+                // — antes ficava espaco em branco sem borda, truncando o
+                // quadro visualmente.
                 for (; i2 < numeroElementosLinha; i2++)
-                    fl.ComElemento (new ElementoVazio ());
+                    fl.ComElemento (new CelulaVazia (estilo));
 
                 fl.ComLargurasIguais ();
                 MainVerticalStack.Add (fl);

--- a/DanfeSharp/Blocos/BlocoFormaPagamento.cs
+++ b/DanfeSharp/Blocos/BlocoFormaPagamento.cs
@@ -1,0 +1,67 @@
+using System.Collections.Generic;
+using System.Linq;
+using DanfeSharp.Elementos;
+using DanfeSharp.Modelo;
+
+namespace DanfeSharp.Blocos
+{
+    /// <summary>
+    /// Bloco "Forma de Pagamento" da DANFE de NF-e modelo 55.
+    /// Renderiza um <see cref="PagamentoDetalhe"/> por <c>DetalheViewModel</c>
+    /// usando o mesmo padrão visual de <see cref="BlocoDuplicataFatura"/>:
+    /// múltiplos detalhes lado a lado em uma <c>FlexibleLine</c>, cada um com
+    /// 2 colunas (FORMA PAGAMENTO + VALOR).
+    /// </summary>
+    /// <remarks>
+    /// <para>O bloco é omitido quando <see cref="DanfeViewModel.Pagamento"/> está vazio
+    /// ou nenhum <see cref="PagamentoViewModel.DetalhePagamento"/> está preenchido —
+    /// preserva compat com NF-e anteriores à NT 2016.002.</para>
+    /// <para>Referência: openspec/specs/danfe-payment-block/spec.md.</para>
+    /// </remarks>
+    internal class BlocoFormaPagamento : BlocoBase
+    {
+        public BlocoFormaPagamento(DanfeViewModel viewModel, Estilo estilo)
+            : base(viewModel, estilo)
+        {
+            var detalhes = ViewModel.Pagamento?
+                .SelectMany(p => p.DetalhePagamento ?? new List<DetalheViewModel>())
+                .Select(d => new PagamentoDetalhe(estilo, d))
+                .ToList();
+
+            if (detalhes == null || detalhes.Count == 0) return;
+
+            var eh = detalhes.First().Height;
+
+            // Espelha o layout de BlocoDuplicataFatura: N por linha conforme
+            // orientação. Pagamento tem labels mais longas (ex.: "Pagamento
+            // Instantâneo (PIX)" = 28 chars) — limitar cards/linha para a
+            // descrição caber sem sobrepor com o VALOR adjacente.
+            int numeroElementosLinha = ViewModel.IsPaisagem ? 3 : 2;
+            int i = 0;
+
+            while (i < detalhes.Count)
+            {
+                var fl = new FlexibleLine(Width, eh);
+
+                int i2;
+                for (i2 = 0; i2 < numeroElementosLinha && i < detalhes.Count; i2++, i++)
+                {
+                    fl.ComElemento(detalhes[i]);
+                }
+
+                // Preenche o restante da linha com células vazias (apenas
+                // borda) — mesma técnica de BlocoDuplicataFatura, para que
+                // o quadro vá até a margem direita quando há menos formas
+                // de pagamento do que colunas.
+                for (; i2 < numeroElementosLinha; i2++)
+                    fl.ComElemento(new CelulaVazia(estilo));
+
+                fl.ComLargurasIguais();
+                MainVerticalStack.Add(fl);
+            }
+        }
+
+        public override string Cabecalho => "Forma de Pagamento";
+        public override PosicaoBloco Posicao => PosicaoBloco.Topo;
+    }
+}

--- a/DanfeSharp/Blocos/TabelaProdutosServicos.cs
+++ b/DanfeSharp/Blocos/TabelaProdutosServicos.cs
@@ -22,18 +22,18 @@ namespace DanfeSharp.Blocos
             var ae = AlinhamentoHorizontal.Esquerda;
 
             Tabela = new Tabela(Estilo);
-            String cabecalho4 = ViewModel.Emitente.CRT == "3" ? "O/CST" : "O/CSOSN";
+            String cabecalho4 = ProdutoViewModel.CalcularCabecalhoColunaIcms(ViewModel.Produtos);
 
             if (ViewModel.IsRetrato)
             { 
                 Tabela
                 .ComColuna(8.5f, ac, "CÓDIGO", "PRODUTO")
                 .ComColuna(0, ae, "DESCRIÇÃO DO PRODUTO / SERVIÇO")
-                .ComColuna(5.6F, ac, "NCM/SH")
+                .ComColuna(5F, ac, "NCM/SH")
                 .ComColuna(3.9F, ac, cabecalho4)
                 .ComColuna(3.5F, ac, "CFOP")
                 .ComColuna(3.25F, ac, "UN")
-                .ComColuna(6F, ad, "QUANTI.")
+                .ComColuna(4F, ad, "QUANT.")
                 .ComColuna(6F, ad, "VALOR", "UNIT.")
                 .ComColuna(6F, ad, "VALOR", "TOTAL")
                 .ComColuna(6F, ad, "B CÁLC", "ICMS")
@@ -48,11 +48,11 @@ namespace DanfeSharp.Blocos
                 Tabela
                 .ComColuna(8.1f, ac, "CÓDIGO PRODUTO")
                 .ComColuna(0, ae, "DESCRIÇÃO DO PRODUTO / SERVIÇO")
-                .ComColuna(5.5F, ac, "NCM/SH")
+                .ComColuna(5F, ac, "NCM/SH")
                 .ComColuna(3.1F, ac, cabecalho4)
                 .ComColuna(3.1F, ac, "CFOP")
                 .ComColuna(3F, ac, "UN")
-                .ComColuna(5.25F, ad, "QUANTI.")
+                .ComColuna(4.00F, ad, "QUANT.")
                 .ComColuna(5.6F, ad, "VALOR UNIT.")
                 .ComColuna(5.6F, ad, "VALOR TOTAL")
                 .ComColuna(5.6F, ad, "B CÁLC ICMS")

--- a/DanfeSharp/Danfe.cs
+++ b/DanfeSharp/Danfe.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using DanfeSharp.Blocos;
 using org.pdfclown.documents;
 using org.pdfclown.documents.contents.fonts;
@@ -66,6 +67,9 @@ namespace DanfeSharp
 
             if (ViewModel.Duplicatas.Count > 0)
                 AdicionarBloco<BlocoDuplicataFatura>();
+
+            if (ViewModel.Pagamento != null && ViewModel.Pagamento.Any(p => p.DetalhePagamento != null && p.DetalhePagamento.Count > 0))
+                AdicionarBloco<BlocoFormaPagamento>();
 
             AdicionarBloco<BlocoCalculoImposto>(ViewModel.Orientacao == Orientacao.Paisagem ? EstiloPadrao : CriarEstilo(4.75F));
             AdicionarBloco<BlocoTransportador>();
@@ -138,12 +142,42 @@ namespace DanfeSharp
             if (_FoiGerado) throw new InvalidOperationException("O Danfe já foi gerado.");
 
             IdentificacaoEmitente.Logo = _LogoObject;
-            var tabela = new TabelaProdutosServicos(ViewModel, EstiloPadrao);      
-                    
+            var tabela = new TabelaProdutosServicos(ViewModel, EstiloPadrao);
+
+            int paginasSemEspacoConsecutivas = 0;
+
             while (true)
             {
                 DanfePagina p = CriarPagina();
-               
+
+                // Quando os blocos do topo (Emitente, Destinatário, Local de
+                // Entrega/Retirada, Fatura, Cálculo do Imposto, Forma de
+                // Pagamento, Transportador, Dados Adicionais) consomem toda a
+                // altura disponível — situação comum em paisagem com NF-e
+                // ricas — RetanguloCorpo fica com Height ≤ 0 e a tabela de
+                // produtos não tem onde renderizar. Antes, isso lançava
+                // InvalidOperationException; agora pulamos para a próxima
+                // página, onde apenas BlocoIdentificacaoEmitente é desenhado
+                // (único com VisivelSomentePrimeiraPagina = false) e sobra
+                // espaço para a tabela.
+                if (p.RetanguloCorpo.Size.Height <= 0)
+                {
+                    paginasSemEspacoConsecutivas++;
+                    // Proteção contra loop infinito: se 2 páginas seguidas não
+                    // têm espaço, algo está fundamentalmente errado com o
+                    // layout — aborta com mensagem útil.
+                    if (paginasSemEspacoConsecutivas > 1)
+                    {
+                        throw new InvalidOperationException(
+                            "Não foi possível renderizar a tabela de produtos: " +
+                            "os blocos do cabeçalho consomem toda a altura disponível em duas páginas consecutivas. " +
+                            "Reduza blocos opcionais (LocalRetirada/LocalEntrega, infCpl longas) ou use orientação Retrato.");
+                    }
+                    continue;
+                }
+
+                paginasSemEspacoConsecutivas = 0;
+
                 tabela.SetPosition(p.RetanguloCorpo.Location);
                 tabela.SetSize(p.RetanguloCorpo.Size);
                 tabela.Draw(p.Gfx);
@@ -179,6 +213,17 @@ namespace DanfeSharp
             if (ViewModel.TipoAmbiente == 2)
             {
                 p.DesenharAvisoHomologacao();
+            }
+
+            // NF-e cancelada — marca d'água "DOCUMENTO CANCELADO".
+            // Detecção primária via ViewModel.IsCancelled (flag explícita do
+            // consumer, refletindo cancelamento via evento NFeProcEvento
+            // tpEvento=110111). Fallback via cStat==101 cobre cenário raro de
+            // XML modificado para refletir cancelamento (compatibilidade com
+            // abordagem da PR #8 de 2023). Ver spec danfe-cancelled-watermark.
+            if (ViewModel.IsCancelled || ViewModel.CodigoStatusReposta == 101)
+            {
+                p.DesenharAvisoCancelamento();
             }
 
             return p;

--- a/DanfeSharp/DanfePagina.cs
+++ b/DanfeSharp/DanfePagina.cs
@@ -103,6 +103,27 @@ namespace DanfeSharp
             Gfx.PrimitiveComposer.End();
         }
 
+        /// <summary>
+        /// Desenha marca d'água "DOCUMENTO CANCELADO" centralizada no corpo da
+        /// página. Padrão visual herdado de <see cref="DesenharAvisoHomologacao"/>
+        /// — mesma fonte 48pt, mesma cor cinza médio RGB(0.35, 0.35, 0.35).
+        /// Referência original: PR #8 do @mateuszanini (2023, branch
+        /// feature/aviso-cancelamento), commit f658489. Disparo agora vem da
+        /// flag <see cref="DanfeSharp.Modelo.DanfeViewModel.IsCancelled"/> em
+        /// vez do cStat=101 do XML — reflete a realidade do cancelamento via
+        /// evento separado em NF-e modelo 55.
+        /// </summary>
+        public void DesenharAvisoCancelamento()
+        {
+            TextStack ts = new TextStack(RetanguloCorpo) { AlinhamentoVertical = AlinhamentoVertical.Centro, AlinhamentoHorizontal = AlinhamentoHorizontal.Centro, LineHeightScale = 0.9F }
+                        .AddLine("DOCUMENTO CANCELADO", Danfe.EstiloPadrao.CriarFonteRegular(48));
+
+            Gfx.PrimitiveComposer.BeginLocalState();
+            Gfx.PrimitiveComposer.SetFillColor(new org.pdfclown.documents.contents.colorSpaces.DeviceRGBColor(0.35, 0.35, 0.35));
+            ts.Draw(Gfx);
+            Gfx.PrimitiveComposer.End();
+        }
+
         public void DesenharBlocos(bool isPrimeirapagina = false)
         {
             if (isPrimeirapagina && Danfe.ViewModel.QuantidadeCanhotos > 0) DesenharCanhoto();

--- a/DanfeSharp/Elementos/CelulaVazia.cs
+++ b/DanfeSharp/Elementos/CelulaVazia.cs
@@ -1,0 +1,18 @@
+namespace DanfeSharp
+{
+    /// <summary>
+    /// Célula vazia (apenas borda, sem conteúdo) usada para preencher
+    /// linhas incompletas em blocos tabulares como
+    /// <see cref="Blocos.BlocoDuplicataFatura"/> e
+    /// <see cref="Blocos.BlocoFormaPagamento"/>: quando o número de itens
+    /// não fecha a linha (1 duplicata num bloco que cabe 3, p. ex.), as
+    /// posições restantes ficavam visualmente vazias e o quadro parecia
+    /// truncado. <c>CelulaVazia</c> mantém a continuidade do retângulo até
+    /// a margem direita herdando o desenho da borda de
+    /// <see cref="ElementoBase.Draw"/>.
+    /// </summary>
+    internal class CelulaVazia : ElementoBase
+    {
+        public CelulaVazia(Estilo estilo) : base(estilo) { }
+    }
+}

--- a/DanfeSharp/Elementos/PagamentoDetalhe.cs
+++ b/DanfeSharp/Elementos/PagamentoDetalhe.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Drawing;
 using DanfeSharp.Graphics;
 using DanfeSharp.Modelo;
@@ -6,23 +6,24 @@ using DanfeSharp.Modelo;
 namespace DanfeSharp
 {
     /// <summary>
-    /// Elemento que desenha uma duplicata do quadro "FATURA / DUPLICATA" da DANFE.
-    /// Layout: 3 colunas horizontais lado a lado (Número | Vencimento | Valor),
-    /// cada coluna com label em cima e valor abaixo — segue o mesmo padrão visual
-    /// do <c>BlocoCalculoImposto</c> e demais blocos com campos. Antes desta change
-    /// os 3 campos ficavam empilhados verticalmente dentro de uma única coluna —
-    /// reportado pelo cliente Revenda Mais durante revisão do PR #42.
+    /// Elemento que desenha um <c>DetalheViewModel</c> do quadro
+    /// "FORMA DE PAGAMENTO" da DANFE.
+    /// Layout: 2 colunas horizontais lado a lado (FORMA PAGAMENTO | VALOR),
+    /// cada coluna com label em cima e conteúdo abaixo — mesmo padrão visual
+    /// de <see cref="Duplicata"/> (quadro Fatura/Duplicata).
     /// </summary>
     [AlturaFixa]
-    internal class Duplicata : ElementoBase
+    internal class PagamentoDetalhe : ElementoBase
     {
         public Fonte FonteA { get; private set; }
         public Fonte FonteB { get; private set; }
-        public DuplicataViewModel ViewModel { get; private set; }
+        public DetalheViewModel ViewModel { get; private set; }
 
-        private static readonly String[] Chaves = { "Número", "Vencimento:", "Valor:" };
+        // Title Case espelhando o padrão de Duplicata.cs (Chaves = {"Número",
+        // "Vencimento:", "Valor:"}) — primeira label sem ':', segunda com.
+        private static readonly String[] Chaves = { "Forma de Pagamento", "Valor:" };
 
-        public Duplicata(Estilo estilo, DuplicataViewModel viewModel) : base(estilo)
+        public PagamentoDetalhe(Estilo estilo, DetalheViewModel viewModel) : base(estilo)
         {
             ViewModel = viewModel;
             FonteA = estilo.CriarFonteRegular(7.5F);
@@ -35,7 +36,14 @@ namespace DanfeSharp
 
             var r = BoundingBox.InflatedRetangle(Estilo.PaddingSuperior, Estilo.PaddingInferior, Estilo.PaddingHorizontal);
 
-            String[] valores = { ViewModel.Numero, ViewModel.Vecimento.Formatar(), ViewModel.Valor.FormatarMoeda() };
+            // Descrição: prevalece xPag (DetalheViewModel.Descricao) sobre o
+            // [Description] do enum FormaPagamento — regra da spec
+            // danfe-payment-block.
+            String descricao = !String.IsNullOrEmpty(ViewModel.Descricao)
+                ? ViewModel.Descricao
+                : ViewModel.FormaPagamento.GetDescricao();
+
+            String[] valores = { descricao, ((double?)(double)ViewModel.Valor).FormatarMoeda() };
 
             float colWidth = r.Width / Chaves.Length;
 

--- a/DanfeSharp/Esquemas/ProcNFe.cs
+++ b/DanfeSharp/Esquemas/ProcNFe.cs
@@ -407,6 +407,12 @@ namespace DanfeSharp.Esquemas.NFe
         /// </summary>
         public FormaPagamento tPag { get; set; }
 
+        /// <summary>
+        /// YA03 - Descrição do pagamento. Obrigatório quando <see cref="tPag"/>
+        /// for <see cref="FormaPagamento.fpOutro"/> (99); opcional caso contrário.
+        /// </summary>
+        public string xPag { get; set; }
+
         public decimal vPag { get; set; }
 
         public card card { get; set; }

--- a/DanfeSharp/Modelo/DanfeViewModel.cs
+++ b/DanfeSharp/Modelo/DanfeViewModel.cs
@@ -220,6 +220,22 @@ namespace DanfeSharp.Modelo
         public int? CodigoStatusReposta { get; set; }
 
         /// <summary>
+        /// <para>Sinaliza que a NF-e foi cancelada — quando <c>true</c>, a DANFE
+        /// renderiza marca d'água "DOCUMENTO CANCELADO" centralizada em todas
+        /// as páginas.</para>
+        /// <para>Como o cancelamento em NF-e modelo 55 acontece via evento
+        /// separado (NFeProcEvento, <c>tpEvento=110111</c>) e NÃO altera o
+        /// <c>cStat</c> do XML da NF-e original (que permanece 100 — Autorizado),
+        /// o consumer DEVE setar essa flag explicitamente com base no estado
+        /// real do sistema (banco de dados / histórico de eventos), não no XML
+        /// carregado.</para>
+        /// <para>Como fallback, o renderer também desenha a marca quando
+        /// <see cref="CodigoStatusReposta"/> == 101 (cobre cenário raro onde
+        /// o XML carregado já reflete o cancelamento).</para>
+        /// </summary>
+        public bool IsCancelled { get; set; }
+
+        /// <summary>
         /// Descrição do status da resposta, xMotivo, do elemento infProt.
         /// </summary>
         public String DescricaoStatusReposta { get; set; }

--- a/DanfeSharp/Modelo/DanfeViewModelCreator.cs
+++ b/DanfeSharp/Modelo/DanfeViewModelCreator.cs
@@ -324,6 +324,7 @@ namespace DanfeSharp.Modelo
                     var detalhe = new DetalheViewModel();
 
                     detalhe.FormaPagamento = (FormaPagamento)detPag.tPag;
+                    detalhe.Descricao = String.IsNullOrEmpty(detPag.xPag) ? null : detPag.xPag;
                     detalhe.Valor = detPag.vPag;
 
                     pagamento.DetalhePagamento.Add(detalhe);
@@ -494,7 +495,9 @@ namespace DanfeSharp.Modelo
                             produto.ValorIcms = icms.vICMS;
                             produto.BaseIcms = icms.vBC;
                             produto.AliquotaIcms = icms.pICMS;
-                            produto.OCst = icms.orig + icms.CST + icms.CSOSN;
+                            produto.Origem = String.IsNullOrEmpty(icms.orig) ? null : icms.orig;
+                            produto.Cst = String.IsNullOrEmpty(icms.CST) ? null : icms.CST;
+                            produto.Csosn = String.IsNullOrEmpty(icms.CSOSN) ? null : icms.CSOSN;
                             produto.BaseIcmsST = icms.vBCST;
                         }
                     }
@@ -592,6 +595,34 @@ namespace DanfeSharp.Modelo
 
             model.ContingenciaDataHora = ide.dhCont;
             model.ContingenciaJustificativa = ide.xJust;
+
+            // Grupo YA - Informações de Pagamento (obrigatório em NF-e v4.0+
+            // pela NT 2016.002 v1.50). Popula model.Pagamento espelhando o
+            // mesmo caminho do CreateFromProcNFCe — necessário para que o
+            // BlocoFormaPagamento renderize na DANFE de NF-e modelo 55.
+            if (infNfe.pag != null)
+            {
+                foreach (var pag in infNfe.pag)
+                {
+                    var pagamento = new PagamentoViewModel();
+                    pagamento.DetalhePagamento = new List<DetalheViewModel>();
+                    pagamento.Troco = pag.vTroco;
+
+                    if (pag.detPag != null)
+                    {
+                        foreach (var detPag in pag.detPag)
+                        {
+                            var detalhe = new DetalheViewModel();
+                            detalhe.FormaPagamento = (FormaPagamento)detPag.tPag;
+                            detalhe.Descricao = String.IsNullOrEmpty(detPag.xPag) ? null : detPag.xPag;
+                            detalhe.Valor = detPag.vPag;
+                            pagamento.DetalhePagamento.Add(detalhe);
+                        }
+                    }
+
+                    model.Pagamento.Add(pagamento);
+                }
+            }
 
             return model;
         }

--- a/DanfeSharp/Modelo/FormaPagamentoExtensions.cs
+++ b/DanfeSharp/Modelo/FormaPagamentoExtensions.cs
@@ -1,0 +1,35 @@
+using System;
+using System.ComponentModel;
+using System.Reflection;
+using DanfeSharp.Esquemas.NFe;
+
+namespace DanfeSharp.Modelo
+{
+    /// <summary>
+    /// Helpers para o enum <see cref="FormaPagamento"/>.
+    /// </summary>
+    /// <remarks>
+    /// Referência: openspec/specs/danfe-payment-block/spec.md (Requirement
+    /// "Helper FormaPagamento.GetDescricao() reusable across the project").
+    /// </remarks>
+    public static class FormaPagamentoExtensions
+    {
+        /// <summary>
+        /// Retorna a descrição legível do valor (lida do <see cref="DescriptionAttribute"/>
+        /// declarado no enum). Para valor não definido no enum, retorna string vazia
+        /// — nunca null nem exceção, conforme spec.
+        /// </summary>
+        public static string GetDescricao(this FormaPagamento formaPagamento)
+        {
+            Type type = typeof(FormaPagamento);
+            string name = Enum.GetName(type, formaPagamento);
+            if (string.IsNullOrEmpty(name)) return string.Empty;
+
+            FieldInfo field = type.GetField(name);
+            if (field == null) return string.Empty;
+
+            DescriptionAttribute attr = field.GetCustomAttribute<DescriptionAttribute>();
+            return attr?.Description ?? string.Empty;
+        }
+    }
+}

--- a/DanfeSharp/Modelo/PagamentoViewModel.cs
+++ b/DanfeSharp/Modelo/PagamentoViewModel.cs
@@ -27,6 +27,14 @@ namespace DanfeSharp.Modelo
         public FormaPagamento FormaPagamento { get; set; }
 
         /// <summary>
+        /// <para>Descrição livre da forma de pagamento (tag xPag).</para>
+        /// <para>Quando preenchida, prevalece sobre a descrição padrão do enum
+        /// <see cref="FormaPagamento"/> na renderização da DANFE. Obrigatória
+        /// quando <see cref="FormaPagamento"/> = <see cref="FormaPagamento.fpOutro"/>.</para>
+        /// </summary>
+        public string Descricao { get; set; }
+
+        /// <summary>
         /// Valor do Pagamento (vPag)
         /// </summary>
         public decimal Valor { get; set; }

--- a/DanfeSharp/Modelo/ProdutoViewModel.cs
+++ b/DanfeSharp/Modelo/ProdutoViewModel.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace DanfeSharp.Modelo
 {
@@ -29,10 +31,55 @@ namespace DanfeSharp.Modelo
         public String Ncm { get; set; }
 
         /// <summary>
-        /// <para>Origem da mercadoria + Tributação do ICMS</para>
-        /// <para>Tag orig e CST</para>
+        /// <para>Origem da mercadoria.</para>
+        /// <para>Tag <c>orig</c> do grupo <c>ICMS*</c>.</para>
         /// </summary>
-        public String OCst { get; set; }
+        public String Origem { get; set; }
+
+        /// <summary>
+        /// <para>Código de Tributação do ICMS para emitente do Regime Normal.</para>
+        /// <para>Tag <c>CST</c> do grupo <c>ICMS*</c>. Mutuamente exclusivo com <see cref="Csosn"/>.</para>
+        /// </summary>
+        public String Cst { get; set; }
+
+        /// <summary>
+        /// <para>Código de Tributação do ICMS para emitente do Simples Nacional.</para>
+        /// <para>Tag <c>CSOSN</c> do grupo <c>ICMSSN*</c>. Mutuamente exclusivo com <see cref="Cst"/>.</para>
+        /// </summary>
+        public String Csosn { get; set; }
+
+        // Backing para o setter público legacy de OCst. Usado apenas quando o
+        // consumer atribui OCst diretamente sem popular Origem/Cst/Csosn — ver
+        // setter abaixo.
+        private String _ocstLegacy;
+
+        /// <summary>
+        /// <para>Composição "Origem/Código" exibida na coluna ICMS da DANFE.</para>
+        /// <para>Computado a partir de <see cref="Origem"/> + (<see cref="Cst"/> ?? <see cref="Csosn"/>),
+        /// separados por <c>/</c>. Omite componentes vazios — XMLs sem <c>orig</c>
+        /// exibem só o código (sem barra solta no início).</para>
+        /// <para>O setter é mantido como <c>[Obsolete]</c> para preservar compatibilidade
+        /// de ABI/source com consumers que construíam <see cref="ProdutoViewModel"/>
+        /// atribuindo <c>OCst</c> diretamente (uso típico antes da introdução de
+        /// <see cref="Origem"/>/<see cref="Cst"/>/<see cref="Csosn"/>). O valor atribuído
+        /// só é usado quando <see cref="Origem"/>, <see cref="Cst"/> e <see cref="Csosn"/>
+        /// estão todos vazios — caso contrário a composição dinâmica prevalece.</para>
+        /// </summary>
+        public String OCst
+        {
+            get
+            {
+                String codigo = !String.IsNullOrEmpty(Cst) ? Cst : Csosn;
+                Boolean temOrigem = !String.IsNullOrEmpty(Origem);
+                Boolean temCodigo = !String.IsNullOrEmpty(codigo);
+                if (temOrigem && temCodigo) return Origem + "/" + codigo;
+                if (temOrigem) return Origem;
+                if (temCodigo) return codigo;
+                return _ocstLegacy ?? String.Empty;
+            }
+            [Obsolete("Atribua Origem e Cst (ou Csosn) separadamente; OCst agora é derivado. Setter mantido apenas para compatibilidade.")]
+            set => _ocstLegacy = value;
+        }
 
         /// <summary>
         /// <para>Código Fiscal de Operações e Prestações</para>
@@ -124,6 +171,20 @@ namespace DanfeSharp.Modelo
         {
             AliquotaIpi = null;
             ValorIpi = null;
+        }
+
+        /// <summary>
+        /// Calcula o cabeçalho da coluna ICMS na tabela de produtos da DANFE
+        /// (<c>"O/CST"</c> ou <c>"O/CSOSN"</c>) a partir do conteúdo dos itens
+        /// — abordagem mais robusta que confiar em <c>Emitente.CRT</c>.
+        /// Ver <c>openspec/changes/fix-danfe-csosn-rendering/design.md</c> (Decision 1).
+        /// </summary>
+        public static String CalcularCabecalhoColunaIcms(IEnumerable<ProdutoViewModel> produtos)
+        {
+            if (produtos == null) return "O/CST";
+            Boolean temCst = produtos.Any(p => !String.IsNullOrEmpty(p.Cst));
+            Boolean temCsosn = produtos.Any(p => !String.IsNullOrEmpty(p.Csosn));
+            return temCst ? "O/CST" : (temCsosn ? "O/CSOSN" : "O/CST");
         }
 
         public String DescricaoCompleta

--- a/openspec/changes/archive/2026-05-28-add-cancelled-watermark/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-28-add-cancelled-watermark/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-28

--- a/openspec/changes/archive/2026-05-28-add-cancelled-watermark/design.md
+++ b/openspec/changes/archive/2026-05-28-add-cancelled-watermark/design.md
@@ -1,0 +1,145 @@
+## Context
+
+DanfeSharp renderiza DANFE em PDF a partir de XML de NF-e. Para ambiente de homologação (NF-e emitida em ambiente de testes da SEFAZ), o renderer já desenha uma marca d'água "SEM VALOR FISCAL — AMBIENTE DE HOMOLOGAÇÃO" centralizada em cada página da DANFE — pattern em `DanfePagina.DesenharAvisoHomologacao()` (linha 97), chamado por `Danfe.CriarPagina()` quando `ViewModel.TipoAmbiente != 1`.
+
+**Realidade do cancelamento em NF-e modelo 55** (input crítico do usuário durante o review): o cancelamento NÃO acontece via alteração da própria NF-e — ele é registrado via **evento separado** (`NFeProcEvento` com `tpEvento=110111` — Cancelamento), que retorna `cStat=135` (Evento registrado e vinculado a NF-e). O XML original da NF-e (`<NFe><protNFe><infProt>`) mantém `cStat=100` (Autorizado) mesmo após o cancelamento — quem sabe que a nota foi cancelada é o sistema do emissor, consultando o histórico de eventos da chave de acesso.
+
+O `cStat=101` aparece apenas em:
+- Retornos de autorização rejeitada com motivo "NF-e já cancelada" (raro);
+- Alguns sistemas que **modificam o XML carregado** para refletir o status atual (não padrão, mas existe);
+- O próprio XML de evento de cancelamento, em campos diferentes do `infProt.cStat`.
+
+A consequência: **detectar cancelamento via `infProt.cStat == 101`** (como a [PR #8](https://github.com/nfe/DanfeSharp/pull/8) do @mateuszanini fez em 2023) **funciona em casos limítrofes**, mas não cobre o cenário comum de produção. O emissor do sistema é quem sabe pelo banco de dados que a NF-e foi cancelada e precisa **informar isso ao renderer** explicitamente.
+
+**Estado atual do código (auditado)**
+
+- `DanfeSharp/Modelo/DanfeViewModel.cs:220` — propriedade `CodigoStatusReposta` (int?) já existe, populada por `DanfeViewModelCreator.cs:414` lendo `infProt.cStat` do XML protocolo.
+- `DanfeSharp/DanfePagina.cs:97` — método `DesenharAvisoHomologacao()` usa `TextStack` centralizado com `Danfe.EstiloPadrao.CriarFonteRegular(48)` (texto "SEM VALOR FISCAL") + `CriarFonteRegular(30)` (texto "AMBIENTE DE HOMOLOGAÇÃO"), cor `RGB(0.35, 0.35, 0.35)`. Padrão visual robusto e estabelecido.
+- `DanfeSharp/Danfe.cs:CriarPagina` (linha ~167-195) — onde a página é construída; já tem condicional `if (ViewModel.TipoAmbiente != 1) p.DesenharAvisoHomologacao();` (homologação).
+- `Paginas` é `List<DanfePagina>` — o renderer já é multi-página (graças ao fix de paginação aplicado em `feature/danfe-forma-pagamento`).
+- PR #8 do @mateuszanini contém commit `f658489` com o método `DesenharAvisoCancelamento()` já escrito — texto "DOCUMENTO CANCELADO", mesma estrutura de `DesenharAvisoHomologacao`. Vou reaproveitar.
+
+**Base normativa**
+
+[MOC 7.0 — Anexo II §3.10.1](https://www.confaz.fazenda.gov.br/legislacao/arquivo-manuais/moc7-anexo-ii-manual-especificacoes-tecnicas-danfe-codigo-barras.pdf) (Marca d'Água), literal:
+
+> "O formulário poderá conter marca d'água desde que não prejudique a legibilidade dos dados impressos."
+
+Apenas isso. Verifiquei literalmente o PDF do CONFAZ em 2026-05-28 (via `pdftotext -enc UTF-8`). O MOC **autoriza** o uso, **não obriga** marca para NF-e cancelada, **não especifica** texto/posição/opacidade. O texto "DOCUMENTO CANCELADO" e o estilo (fonte 48pt cinza centralizada) são **convenção universal de mercado** alinhada ao padrão existente do `DesenharAvisoHomologacao`. Como nos casos #38 e #39 desta sprint, esta change segue a convenção sem reivindicar conformidade normativa específica.
+
+**Stakeholders**
+
+- Cliente **Revenda Mais** (relator)
+- Consumidores externos do `nfe/DanfeSharp` (API NFe.io que precisa renderizar DANFE de notas canceladas)
+- Receptores das DANFEs (contadores, fiscais)
+
+**Constraints**
+
+- Manter compatibilidade total: DANFE de NF-e não-cancelada renderiza idêntico (zero regressão).
+- Sem breaking changes na API pública.
+- Funcionar em retrato + paisagem + multi-página.
+- Funcionar em ambiente de produção E homologação simultaneamente (NF-e de homologação que foi cancelada → ambos os avisos aparecem).
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Marca d'água "DOCUMENTO CANCELADO" centralizada visível em cada página da DANFE quando a NF-e está cancelada.
+- Mecanismo primário de detecção: flag explícita `DanfeViewModel.IsCancelled` (que o consumer NFe.io seta com base no estado real do banco de dados, não do XML).
+- Mecanismo fallback: `CodigoStatusReposta == 101` continua acionando a marca, para o cenário (raro mas existente) de XML modificado pelo consumer para refletir cancelamento.
+- Zero impacto em DANFE de NF-e ativa.
+- Suporte para todas as orientações (retrato, paisagem) e em multi-página.
+- Co-existência com aviso de homologação (uma NF-e cancelada em homologação mostra os dois avisos sobrepostos — comportamento esperado, sinaliza claramente o estado).
+
+**Non-Goals:**
+
+- Não tratar outros estados (denegada — `cStat=110`; inutilizada — `cStat=102` quando inutilização; EPEC). Cada um teria texto distinto e fluxo próprio — fora do escopo desta change.
+- Não tratar DANFE NFCe (modelo 65) — manual e renderer separados.
+- Não parsear o XML do **evento de cancelamento** (`procEventoNFe`) automaticamente. O consumer fornece o `IsCancelled` flag baseado em conhecimento próprio. Parsear o evento exigiria expandir o `DanfeViewModelCreator` para aceitar 2 XMLs (NF-e + evento), o que é uma refatoração maior — pode ser nova change futura se a demanda aparecer.
+- Não permitir customização do texto da marca via API (sempre "DOCUMENTO CANCELADO"). Se aparecer demanda específica de cliente, vira nova change.
+- Não suportar transparência via PDF alpha channel — fica com cor cinza sólida (mesmo padrão do "SEM VALOR FISCAL"). Transparência real exigiria investigação da PDFClown.NetStandard API — não vale o trade-off no momento.
+
+## Decisions
+
+### Decision 1: Detecção via flag `IsCancelled` (primário) + `cStat=101` (fallback OR)
+
+**Escolha:** adicionar `public bool IsCancelled { get; set; }` ao `DanfeViewModel` (default `false`). A condicional em `Danfe.CriarPagina` checa `ViewModel.IsCancelled || ViewModel.CodigoStatusReposta == 101`. Qualquer um dos dois trigger desenha a marca.
+
+**Por que ambos:**
+- Flag explícita é a forma **correta** para o cenário real (cancelamento via evento) — o consumer NFe.io define com base no banco de dados.
+- `cStat=101` mantido por **defense in depth** + compatibilidade com a abordagem original da PR #8 (caso algum consumer já dependa). É OR, então não conflita com a flag.
+- Zero ambiguidade: se algum dos dois é true, marca aparece. Se ambos false (caso comum), não aparece.
+
+**Alternativa rejeitada:** apenas `cStat=101`. Não funciona na prática para cancelamento via evento (cenário comum). PR #8 fez essa escolha em 2023 — seria errado repetir sem ajuste.
+
+**Alternativa rejeitada:** apenas `IsCancelled` flag. Funciona conceitualmente, mas obrigaria toda configuração via código. Manter o fallback de cStat=101 é zero custo e cobre alguns casos atípicos.
+
+**Alternativa rejeitada:** parsear automaticamente o evento de cancelamento se o XML embedded contiver `procEventoNFe` com `tpEvento=110111` e `cStat=135`. Mais "completo" tecnicamente, mas:
+1. Exigiria expandir o `DanfeViewModelCreator` para aceitar/processar a estrutura do evento;
+2. Na prática, sistemas como a API NFe.io não embedam o evento no XML principal — o consumer carrega ambos separadamente do storage;
+3. Aumenta superfície de bugs em troca de elegância marginal;
+4. Pode ser nova change futura (`load-cancellation-event-xml`) se a demanda aparecer.
+
+### Decision 2: Reaproveitar o método `DesenharAvisoCancelamento` da PR #8
+
+**Escolha:** o método criado por @mateuszanini em 2023 (`DanfePagina.cs:DesenharAvisoCancelamento`, +16 linhas no commit `f658489`) é tecnicamente correto — espelha exatamente o `DesenharAvisoHomologacao`, mesmo `TextStack`, mesma cor, mesma fonte 48pt. O problema da PR #8 era o **gatilho** (cStat=101 only), não a renderização. Vou copiar o método dele literalmente (com créditos no commit message).
+
+**Por que reaproveitar:**
+- Trabalho de qualidade — não precisa reescrever.
+- Reconhece a contribuição do @mateuszanini pública (ele tentou em 2023, ficou parado; agora finaliza com mecanismo correto).
+- Reduz risco: padrão visual já validado contra o renderer PDFClown nos avisos de homologação.
+
+### Decision 3: Texto fixo "DOCUMENTO CANCELADO"
+
+**Escolha:** texto invariável `"DOCUMENTO CANCELADO"`, sem configuração via API.
+
+**Por que esse texto:**
+- Concorda gramaticalmente com "DANFE" = "Documento Auxiliar da Nota Fiscal Eletrônica" (masculino → "cancelado").
+- É a convenção visual mais comum em DANFEs comerciais (vi em TOTVS, SAP, SmartGo, eMissor — padrão de mercado).
+- Era a escolha do @mateuszanini na PR #8.
+
+**Alternativa rejeitada:** "CANCELADA" (texto da issue #40, alinhando com a fala da Carolina). Concorda com "Nota Fiscal Eletrônica" (feminino), mas é ambíguo quando vem na DANFE (que é masculino). Decisão favorável a clareza gramatical sobre fidelidade ao texto do solicitante.
+
+**Alternativa rejeitada:** texto configurável via API. Overengineering — não há demanda real para variar texto.
+
+### Decision 4: Sobreposição com aviso de homologação (NF-e cancelada em homologação)
+
+**Escolha:** quando uma NF-e está em homologação **E** está cancelada (cenário atípico de testes), AMBOS os avisos são desenhados — "SEM VALOR FISCAL" (homologação) + "DOCUMENTO CANCELADO" (cancelada), centralizados no mesmo `RetanguloCorpo`. Sobreposição visual aceita.
+
+**Por que aceitar:**
+- Sinaliza explicitamente os dois estados (que são ambos válidos e relevantes).
+- Implementar separação (priorizar um dos avisos) adicionaria complexidade sem ganho real — em produção, NF-e canceladas em homologação são casos de teste, não impressão fiscal real.
+- Receptor que ver os dois avisos sobrepostos entende claramente que é um documento sem valor.
+
+### Decision 5: Cor cinza sólida em vez de transparência real
+
+**Escolha:** usar `RGB(0.35, 0.35, 0.35)` cinza médio sólido (mesmo da PR #8 e do aviso de homologação). Não tentar PDF alpha channel.
+
+**Por que:**
+- Efeito visual idêntico ao "transparente" para o olho humano — texto cinza médio sobre fundo branco fica visualmente "translúcido" sem precisar de transparency object no PDF.
+- Padrão já validado no `DesenharAvisoHomologacao` — visto em milhares de DANFEs em produção sem reclamação de legibilidade.
+- PDFClown.NetStandard pode suportar alpha mas exigiria investigação adicional — trade-off de tempo não vale.
+
+## Risks / Trade-offs
+
+- **[Risk]** Consumer NFe.io pode esquecer de setar `IsCancelled = true` ao gerar DANFE de uma NF-e cancelada → DANFE sairia sem marca. → **Mitigation:** documentar claramente na API (XML doc da propriedade); adicionar exemplo na fixture de testes; coordenar com time da API NFe.io para garantir que setem.
+- **[Risk]** Sobreposição com aviso de homologação pode ficar visualmente confuso. → **Mitigation:** cenário raríssimo (NF-e cancelada em homologação); a sobreposição na verdade reforça "não tem valor fiscal" + "está cancelada", que são informações compatíveis e ambas verdadeiras. Não tratar.
+- **[Trade-off]** Manter detecção via `cStat=101` como fallback adiciona ~5 caracteres na condicional. → Aceito; é defense in depth.
+- **[Risk]** Texto invariável pode não atender cliente futuro com necessidade específica (ex.: "INUTILIZADA", "DENEGADA"). → **Mitigation:** se aparecer, abrir nova change. Premature generalization seria pior.
+
+## Migration Plan
+
+1. Adicionar `IsCancelled` ao `DanfeViewModel.cs` (propriedade pública, default false, com XML doc explicando o uso).
+2. Copiar método `DesenharAvisoCancelamento` da PR #8 para `DanfePagina.cs` (mesmo padrão de `DesenharAvisoHomologacao`).
+3. Adicionar chamada condicional em `Danfe.cs:CriarPagina` após `DesenharAvisoHomologacao`: `if (ViewModel.IsCancelled || ViewModel.CodigoStatusReposta == 101) p.DesenharAvisoCancelamento();`.
+4. Adicionar testes unitários: (a) DANFE sem flag e sem cStat=101 → nenhuma marca; (b) DANFE com `IsCancelled=true` → marca aparece; (c) DANFE com `CodigoStatusReposta=101` → marca aparece; (d) DANFE com ambos → marca aparece uma vez; (e) DANFE multi-página com `IsCancelled=true` → marca em todas as páginas.
+5. Criar fixture demo nova: `v4_DanfeCancelada.xml` (NF-e modelo 55 com infProt.cStat=100 normal) + teste que carrega o XML, seta `model.IsCancelled = true`, gera PDF.
+6. PR draft → review → merge → release.
+
+**Rollback:** se houver regressão visual em produção, revert do PR. Não há migração de dados nem state persistido — DANFE é regenerado a cada request.
+
+## Open Questions
+
+- **Quando o consumer NFe.io vai integrar?** A flag `IsCancelled` é aditiva e default false, então DanfeSharp pode liberar sem coordenação. Mas pra render DANFE cancelada na prática, o time da API precisa setar o flag — alinhar timing com eles. _(Manual, post-merge.)_
+- **Vale criar API tipo `Danfe.FromCancelledInvoice(xml, eventXml)` para parsing automático do evento?** Não nesta change — fica como follow-up se demanda aparecer (ver Non-Goals).
+- **Sobreposição com aviso de homologação fica ruim?** Validar visualmente com fixture específica antes de mergear.

--- a/openspec/changes/archive/2026-05-28-add-cancelled-watermark/proposal.md
+++ b/openspec/changes/archive/2026-05-28-add-cancelled-watermark/proposal.md
@@ -1,0 +1,39 @@
+## Why
+
+O `nfe/DanfeSharp` não tem indicação visual quando o DANFE é gerado para uma **NF-e cancelada**. Receptores fiscais e contadores que recebem o PDF podem confundir o documento com uma NF-e ativa, causando erros operacionais (contabilização indevida, dupla escrita, etc.). Cliente Revenda Mais reportou esse cenário (issue [nfe/DanfeSharp#40](https://github.com/nfe/DanfeSharp/issues/40), umbrella [#37](https://github.com/nfe/DanfeSharp/issues/37)) — eles emitem NF-e que ocasionalmente são canceladas e querem distribuir o PDF cancelado para registro histórico, mas precisam que a marca "CANCELADO" seja evidente.
+
+**Observação técnica crítica:** o cancelamento de NF-e modelo 55 é registrado via **evento separado** (`NFeProcEvento` com `tpEvento=110111`, evento de Cancelamento, retornando `cStat=135` quando autorizado). O XML original da NF-e (`<protNFe><infProt><cStat>`) **permanece com 100 (autorizado)** mesmo após o cancelamento — quem sabe que ela foi cancelada é o sistema do emissor, que consulta o histórico de eventos. Portanto, a detecção via `infProt.cStat == 101` (presente na PR #8 antiga do @mateuszanini, 2023) **não funciona na prática** para a maioria dos casos reais — `cStat=101` é o status de **rejeição** "NF-e já cancelada" quando o emissor tenta processar uma chave já cancelada, não o status normal de uma nota cancelada com sucesso.
+
+## What Changes
+
+- Adicionar propriedade `DanfeViewModel.IsCancelled` (`bool`, default `false`) — flag explícita que o consumidor seta quando sabe que a NF-e está cancelada (informação vinda do banco de dados / sistema do emissor, não do XML da nota).
+- Manter detecção legacy via `CodigoStatusReposta == 101` como fallback OR (zero custo, cobre o cenário raro de XML com infProt já refletindo o status de cancelamento).
+- Criar método `DanfePagina.DesenharAvisoCancelamento()` espelhando o padrão existente de `DesenharAvisoHomologacao()` (mesmo `TextStack` centralizado, fonte 48pt, cor RGB(0.35, 0.35, 0.35) cinza médio).
+- Adicionar chamada condicional em `Danfe.cs:CriarPagina` para desenhar o aviso em **todas as páginas** quando a NF-e está cancelada — independentemente da orientação (retrato/paisagem) e independentemente do ambiente (produção/homologação; numa NF-e cancelada em homologação, ambos os avisos aparecem).
+- Texto da marca: **"DOCUMENTO CANCELADO"** — concorda gramaticalmente com "DANFE" (Documento Auxiliar), é a convenção de mercado mais comum (TOTVS/SAP/SmartGo) e era a escolha do @mateuszanini na PR #8.
+- Renderização funciona para DANFE multi-página: cada página recebe a marca, garantindo que mesmo se receptor olhar só uma folha veja o status.
+- Fixture demo e teste cobrindo: NF-e não-cancelada (zero regressão), NF-e cancelada via flag, NF-e cancelada via cStat=101.
+
+## Capabilities
+
+### New Capabilities
+
+- `danfe-cancelled-watermark`: detecção do estado cancelado da NF-e (via flag `IsCancelled` ou via `cStat=101` legacy) + renderização da marca d'água "DOCUMENTO CANCELADO" centralizada em todas as páginas da DANFE de NF-e modelo 55.
+
+### Modified Capabilities
+
+_Nenhuma — não toca `danfe-icms-column` (#38) nem `danfe-payment-block` (#39)._
+
+## Impact
+
+- **Código afetado** (escopo bem confinado, ~25 linhas no total):
+  - `DanfeSharp/Modelo/DanfeViewModel.cs` — nova propriedade `IsCancelled` (bool, default false)
+  - `DanfeSharp/DanfePagina.cs` — novo método `DesenharAvisoCancelamento()` (espelha `DesenharAvisoHomologacao`)
+  - `DanfeSharp/Danfe.cs:CriarPagina` — adiciona condicional `if (ViewModel.IsCancelled || ViewModel.CodigoStatusReposta == 101) p.DesenharAvisoCancelamento();`
+- **APIs públicas**: aditivas. Nova propriedade `IsCancelled` (default false → comportamento prévio preservado). Nenhuma quebra.
+- **Backward compatibility**: total. Consumidores que não setam `IsCancelled` continuam gerando DANFE sem a marca; comportamento idêntico ao anterior.
+- **Cliente impactado positivamente**: Revenda Mais (escopo direto) + qualquer emissor que precise distribuir DANFE de notas canceladas.
+- **Não impacta**: XML da NF-e, fluxo de cancelamento na SEFAZ, geração da NF-e em si, NFCe (modelo 65, já tem manual próprio), outros eventos (CC-e/Carta de Correção, EPEC, etc.).
+- **Base normativa**: [MOC 7.0 — Anexo II §3.10.1](https://www.confaz.fazenda.gov.br/legislacao/arquivo-manuais/moc7-anexo-ii-manual-especificacoes-tecnicas-danfe-codigo-barras.pdf) (Marca d'Água) autoriza literalmente o uso: *"O formulário poderá conter marca d'água desde que não prejudique a legibilidade dos dados impressos."* — só isso. NÃO obriga nem especifica texto/posição/opacidade para nota cancelada. O texto "DOCUMENTO CANCELADO" e o estilo visual (fonte 48pt cinza centralizada) são **convenção universal de mercado** alinhada com a renderização de "SEM VALOR FISCAL" em ambiente de homologação (que o DanfeSharp já implementa). Verifiquei literalmente o PDF do CONFAZ em 2026-05-28.
+- **Issue mãe**: nfe/DanfeSharp#37; irmãs: nfe/DanfeSharp#38 (mergeado) + nfe/DanfeSharp#39 (PR #42 draft).
+- **Referência prévia**: PR #8 do @mateuszanini (2023, branch `feature/aviso-cancelamento`) — implementação parcialmente correta no commit `f658489` (visual perfeito), mas com detecção via `cStat=101` apenas, que não funciona na prática para o cenário real (cancelamento via evento). Esta change reaproveita o método `DesenharAvisoCancelamento()` dele mas substitui o trigger por `IsCancelled` flag (primário) + `cStat=101` (fallback).

--- a/openspec/changes/archive/2026-05-28-add-cancelled-watermark/specs/danfe-cancelled-watermark/spec.md
+++ b/openspec/changes/archive/2026-05-28-add-cancelled-watermark/specs/danfe-cancelled-watermark/spec.md
@@ -1,0 +1,87 @@
+## ADDED Requirements
+
+> **Base normativa:** [MOC 7.0 — Anexo II §3.10.1](https://www.confaz.fazenda.gov.br/legislacao/arquivo-manuais/moc7-anexo-ii-manual-especificacoes-tecnicas-danfe-codigo-barras.pdf) (Marca d'Água) autoriza literalmente: *"O formulário poderá conter marca d'água desde que não prejudique a legibilidade dos dados impressos."* — não obriga nem especifica texto, posição ou opacidade para NF-e cancelada. Verifiquei o PDF do CONFAZ em 2026-05-28. O texto "DOCUMENTO CANCELADO" e o estilo visual (fonte 48pt, cinza RGB 0.35, centralizada) são **convenção universal de mercado** (TOTVS, SAP, SmartGo, eMissor) alinhada ao padrão do aviso "SEM VALOR FISCAL — AMBIENTE DE HOMOLOGAÇÃO" já implementado no DanfeSharp.
+>
+> **Realidade do cancelamento em NF-e modelo 55:** o cancelamento NÃO é refletido no `<cStat>` do XML protocolo da NF-e original — ele é registrado via **evento separado** (`NFeProcEvento`, `tpEvento=110111`). O consumer (sistema do emissor) é quem sabe que a nota foi cancelada e precisa sinalizar ao renderer via flag explícita. Detecção via `cStat=101` cobre cenário marginal (rejeição "NF-e já cancelada" ou XML modificado pelo consumer).
+
+### Requirement: Detect cancelled invoice via `IsCancelled` flag
+
+O `DanfeSharp.Modelo.DanfeViewModel` SHALL expor propriedade pública `IsCancelled` (`bool`, default `false`). Quando setada como `true`, a DANFE renderiza marca d'água "DOCUMENTO CANCELADO" em todas as páginas. Quando `false` (default), nenhuma marca de cancelamento é desenhada.
+
+#### Scenario: Default false — DANFE renderiza sem marca
+
+- **GIVEN** um `DanfeViewModel` recém-criado (sem setar `IsCancelled`)
+- **WHEN** a DANFE é gerada
+- **THEN** a propriedade `IsCancelled == false` E o PDF gerado não contém marca "DOCUMENTO CANCELADO"
+
+#### Scenario: Consumer seta IsCancelled = true
+
+- **GIVEN** um `DanfeViewModel` carregado de XML de NF-e ativa (`infProt.cStat == 100`)
+- **WHEN** o consumer seta `model.IsCancelled = true` antes de gerar a DANFE
+- **THEN** o PDF gerado contém marca "DOCUMENTO CANCELADO" centralizada em todas as páginas
+
+### Requirement: Detect cancelled invoice via legacy `cStat=101` fallback
+
+Como mecanismo OR adicional (fallback de compatibilidade), a DANFE SHALL renderizar a marca de cancelamento quando `CodigoStatusReposta == 101`, mesmo se `IsCancelled == false`. Cobre o cenário (atípico mas existente) onde o XML protocolo carregado já reflete o status de cancelamento via `cStat=101`.
+
+#### Scenario: XML com infProt.cStat=101
+
+- **GIVEN** um XML de NF-e cujo `<protNFe><infProt><cStat>101</cStat>` está presente e o `DanfeViewModel.CodigoStatusReposta == 101`
+- **WHEN** a DANFE é gerada (sem flag explícita)
+- **THEN** o PDF gerado contém marca "DOCUMENTO CANCELADO" em todas as páginas
+
+#### Scenario: Ambos os mecanismos ativados — marca aparece uma única vez
+
+- **GIVEN** `IsCancelled == true` E `CodigoStatusReposta == 101`
+- **WHEN** a DANFE é gerada
+- **THEN** o PDF contém uma única instância da marca "DOCUMENTO CANCELADO" por página (não duplicada)
+
+### Requirement: Render "DOCUMENTO CANCELADO" watermark on every page
+
+A marca d'água SHALL ser desenhada em **todas** as páginas geradas da DANFE (não só a primeira), garantindo que receptores fiscais identifiquem o status mesmo se receberem apenas folhas individuais de uma DANFE multi-página.
+
+O estilo visual SHALL seguir o padrão do `DesenharAvisoHomologacao` existente: `TextStack` centralizado horizontal e verticalmente no `RetanguloCorpo` (área de produtos da página), fonte `Estilo.CriarFonteRegular(48)`, cor `DeviceRGBColor(0.35, 0.35, 0.35)` cinza médio, `LineHeightScale=0.9F`.
+
+#### Scenario: Single-page DANFE — marca na página única
+
+- **GIVEN** uma DANFE de NF-e cancelada que cabe em 1 página
+- **WHEN** a DANFE é gerada
+- **THEN** a página única do PDF contém a marca
+
+#### Scenario: Multi-page DANFE — marca em todas as páginas
+
+- **GIVEN** uma DANFE de NF-e cancelada com 20 itens (gera ≥ 2 páginas)
+- **WHEN** a DANFE é gerada
+- **THEN** cada página do PDF gerado contém a marca "DOCUMENTO CANCELADO" centralizada
+
+#### Scenario: Visual style spec
+
+- **GIVEN** uma DANFE de NF-e cancelada
+- **WHEN** o PDF é gerado e a marca é extraída visualmente
+- **THEN** o texto "DOCUMENTO CANCELADO" aparece com fonte regular grande (~48pt), cor cinza médio (RGB 0.35,0.35,0.35), centralizado na área principal da página, sem obscurecer dados estruturados (números, descrição de itens) — a cor cinza é leve o suficiente para o conteúdo continuar legível por trás
+
+### Requirement: Co-existence with homologação watermark
+
+Quando uma NF-e está **em homologação E cancelada** simultaneamente (cenário raro, válido em testes), AMBOS os avisos SHALL aparecer na mesma página — "SEM VALOR FISCAL / AMBIENTE DE HOMOLOGAÇÃO" (homologação) **e** "DOCUMENTO CANCELADO" (cancelada). A sobreposição é aceitável porque sinaliza claramente os dois estados, ambos relevantes para o receptor.
+
+#### Scenario: NF-e em homologação cancelada — dois avisos sobrepostos
+
+- **GIVEN** uma NF-e cuja `TipoAmbiente != 1` (homologação) E `IsCancelled == true`
+- **WHEN** a DANFE é gerada
+- **THEN** o PDF contém AMBOS os avisos: "SEM VALOR FISCAL / AMBIENTE DE HOMOLOGAÇÃO" e "DOCUMENTO CANCELADO", centralizados no mesmo retângulo (visualmente sobrepostos)
+
+### Requirement: Zero regression for non-cancelled DANFE
+
+DANFE de NF-e **não cancelada** (`IsCancelled == false` E `CodigoStatusReposta != 101`) SHALL renderizar **idêntica** ao estado anterior a esta change — sem qualquer marca de cancelamento, sem alteração de layout ou tamanho do PDF resultante além de variação atribuível a metadados (alguns bytes).
+
+#### Scenario: DANFE não-cancelada renderiza sem marca
+
+- **GIVEN** uma NF-e ativa (`IsCancelled == false`, `CodigoStatusReposta == 100`)
+- **WHEN** a DANFE é gerada
+- **THEN** o PDF não contém texto "DOCUMENTO CANCELADO" em nenhuma página
+
+#### Scenario: Backward compat — código existente não setou IsCancelled
+
+- **GIVEN** código consumidor que não conhece a nova propriedade `IsCancelled` (escrito antes desta change)
+- **WHEN** chama `DanfeViewModelCreator.CriarDeArquivoXml(path)` e gera a DANFE
+- **THEN** o PDF gerado é idêntico ao gerado antes desta change (zero regressão)

--- a/openspec/changes/archive/2026-05-28-add-cancelled-watermark/tasks.md
+++ b/openspec/changes/archive/2026-05-28-add-cancelled-watermark/tasks.md
@@ -1,0 +1,57 @@
+## 1. ViewModel — propriedade IsCancelled
+
+- [ ] 1.1 Adicionar `public bool IsCancelled { get; set; }` ao `DanfeSharp/Modelo/DanfeViewModel.cs`, com XML doc explicando: "Sinaliza que a NF-e foi cancelada via evento (tpEvento=110111). Quando true, renderiza marca d'água 'DOCUMENTO CANCELADO'. Como o cancelamento em NF-e modelo 55 acontece via evento separado, o consumer deve setar essa flag com base no estado do banco de dados — não vem do XML da NF-e."
+
+## 2. Renderer — método DesenharAvisoCancelamento
+
+- [ ] 2.1 Adicionar método `public void DesenharAvisoCancelamento()` em `DanfeSharp/DanfePagina.cs`, espelhando o padrão de `DesenharAvisoHomologacao` (linha ~97). Texto fixo `"DOCUMENTO CANCELADO"`, fonte `Danfe.EstiloPadrao.CriarFonteRegular(48)`, cor `DeviceRGBColor(0.35, 0.35, 0.35)`, centralizado no `RetanguloCorpo`. Copiado/derivado da PR #8 do @mateuszanini com créditos no commit message.
+
+## 3. Trigger — Danfe.CriarPagina
+
+- [ ] 3.1 Em `DanfeSharp/Danfe.cs`, dentro do método `CriarPagina`, após a chamada existente `if (ViewModel.TipoAmbiente != 1) p.DesenharAvisoHomologacao();`, adicionar `if (ViewModel.IsCancelled || ViewModel.CodigoStatusReposta == 101) p.DesenharAvisoCancelamento();`. Ordem importa: homologação primeiro (se aplicável), cancelamento depois (sobreposição centralizada quando ambos true).
+
+## 4. Testes unitários
+
+- [ ] 4.1 Criar `DanfeSharp.Test/DanfeCanceladaTests.cs` com testes:
+  - (a) `DanfeViewModel_DefaultIsCancelledFalse` — recém-criado, default false.
+  - (b) `Render_IsCancelledTrue_GeraMarca` — carrega fixture XML, seta IsCancelled=true, renderiza, extrai texto via pdftotext, confirma "DOCUMENTO CANCELADO" presente.
+  - (c) `Render_cStat101_GeraMarca` — fixture com cStat=101 no XML, renderiza sem flag, confirma marca presente.
+  - (d) `Render_AmbosTrigger_GeraUmaMarcaPorPagina` — IsCancelled=true E cStat=101, confirma marca aparece uma vez por página (não duplicada).
+  - (e) `Render_NaoCancelada_SemMarca` — XML default + IsCancelled=false, confirma PDF não contém "DOCUMENTO CANCELADO".
+  - (f) `Render_MultiPagina_MarcaEmTodasPaginas` — usa fixture v4_DanfeCompleto (20 itens, multi-página), seta IsCancelled=true, conta ocorrências de "DOCUMENTO CANCELADO" no texto extraído (deve ser >= número de páginas).
+- [ ] 4.2 Atualizar `DanfeSharp.Test/DanfeSharp.Test.csproj` com `<Compile Include="DanfeCanceladaTests.cs" />`.
+
+## 5. Fixture demo
+
+- [ ] 5.1 Não criar XML novo — o estado de cancelamento vem via flag, não via XML. Reaproveitar `v4_DanfeIntermediario.xml` como base. Test method `v4_DanfeIntermediario_Cancelada()` carrega, seta `IsCancelled=true`, gera PDF `v4_DanfeIntermediario_Cancelada.pdf` em `bin/Debug/Output/DeXml/`.
+- [ ] 5.2 Test method `v4_DanfeCompleto_Cancelada()` análogo, para visualizar marca em multi-página (20 itens).
+- [ ] 5.3 Test method `v4_DanfeMinimo_Cancelada()` análogo, para visualizar marca em DANFE simples.
+
+## 6. Build + validação visual
+
+- [ ] 6.1 `dotnet build` → 0 erros.
+- [ ] 6.2 `dotnet vstest --TestCaseFilter:"FullyQualifiedName~DanfeCancelada"` → todos verdes.
+- [ ] 6.3 `dotnet vstest --TestCaseFilter:"FullyQualifiedName~DanfeXmlTests"` → todos os anteriores continuam verdes (zero regressão).
+- [ ] 6.4 Gerar 3 PDFs demo (Mínimo + Intermediário + Completo, todos cancelados) e copiar para `../danfe-payment-validation/exemplos-cancelada/`.
+
+## 7. Documentação no PR
+
+- [ ] 7.1 Body do PR cita PR #8 do @mateuszanini como referência prévia. Reconhece a contribuição dele (visual correto, gatilho equivocado).
+- [ ] 7.2 Body documenta a decisão de detecção primária via flag (vs cStat=101 only) e o motivo (cancelamento via evento na realidade do NF-e modelo 55).
+- [ ] 7.3 Body inclui exemplos visuais (antes/depois) ou link para os PDFs em `../danfe-payment-validation/exemplos-cancelada/`.
+
+## 8. PR + review
+
+- [ ] 8.1 Garantir link `Fixes #40` no body para fechamento automático no merge.
+- [ ] 8.2 Solicitar review do @joaokita (co-assignee automático) + alguém fiscal-aware.
+- [ ] 8.3 Após approval, retirar do draft e mergear.
+
+## 9. Comunicação pós-merge
+
+- [ ] 9.1 Alinhar com time da API NFe.io: setar `model.IsCancelled = true` quando consultarem NF-e cancelada no banco. _(Manual, externo.)_
+- [ ] 9.2 Comentar em PR #8 do @mateuszanini referenciando esta change como continuação/finalização do trabalho dele.
+
+## 10. Arquivamento OpenSpec
+
+- [ ] 10.1 Após merge, `openspec validate add-cancelled-watermark` para confirmar consistência.
+- [ ] 10.2 `openspec archive add-cancelled-watermark -y` para mover a change e promover specs para `openspec/specs/danfe-cancelled-watermark/spec.md`. Preencher o `Purpose` com a base normativa (MOC §3.10.1 autoriza, NT do evento de cancelamento, convenção de mercado).

--- a/openspec/changes/archive/2026-05-28-add-danfe-payment-block/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-28-add-danfe-payment-block/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-28

--- a/openspec/changes/archive/2026-05-28-add-danfe-payment-block/design.md
+++ b/openspec/changes/archive/2026-05-28-add-danfe-payment-block/design.md
@@ -1,0 +1,134 @@
+## Context
+
+DanfeSharp é um renderer de DANFE em C# (.NET netstandard2.0) que carrega o XML da NF-e via `XmlSerializer` (`DanfeSharp.Esquemas.ProcNFe`) e o traduz para um modelo de apresentação (`DanfeSharp.Modelo.DanfeViewModel`) consumido por blocos de desenho. A DANFE atual termina visualmente em "DADOS DOS PRODUTOS / SERVIÇOS" + cálculo de impostos + transportador + dados adicionais — sem qualquer representação de forma de pagamento.
+
+**Estado atual do código (auditado)**
+
+- `DanfeSharp/Esquemas/ProcNFe.cs:386-414` — classes `pag` e `detPag` já existem para deserializar o XML. **Falta a tag `xPag`** (descrição livre da forma de pagamento, especialmente quando `tPag=99`).
+- `DanfeSharp/Esquemas/ProcNFe.cs:1020+` — enum `FormaPagamento` já completo (01–19, 90, 99) com `[Description("...")]` em cada valor (`fpDinheiro="Dinheiro"`, `fpCartaoCredito="Cartão de Crédito"`, etc.). Mapeamento `tPag → descrição` já está pronto para uso.
+- `DanfeSharp/Modelo/PagamentoViewModel.cs` — classes `PagamentoViewModel`, `DetalheViewModel`, `CartaoViewModel` já existem. **Falta a propriedade `Descricao`** em `DetalheViewModel` para refletir `xPag`.
+- `DanfeSharp/Modelo/DanfeViewModel.cs:49-51, 314` — propriedade `Pagamento` (`List<PagamentoViewModel>`) declarada e inicializada.
+- `DanfeSharp/Modelo/DanfeViewModelCreator.cs:318-332` — já popula `model.Pagamento` lendo `pag.detPag`. **Falta** popular `detalhe.Descricao` (que ainda não existe).
+- `DanfeSharp/Blocos/` — pasta com renderers (`BlocoCalculoImposto`, `BlocoTransportador`, etc.). **Não existe** `BlocoFormaPagamento`.
+- `DanfeSharp/Danfe.cs:58-75` — sequência de inserção dos blocos no construtor da `Danfe`. **Nenhuma chamada** a um bloco de pagamento.
+
+**Base normativa**
+
+- O **MOC 7.0 — Anexo II — Manual de Especificações Técnicas do DANFE** ([CONFAZ, Outubro/2020](https://www.confaz.fazenda.gov.br/legislacao/arquivo-manuais/moc7-anexo-ii-manual-especificacoes-tecnicas-danfe-codigo-barras.pdf)) **não tem seção dedicada a forma de pagamento** para DANFE de NF-e modelo 55. Verifiquei literalmente o PDF oficial em 2026-05-28 (extraído via `pdftotext -enc UTF-8`): zero ocorrências de `pagamento`, `forma de pag`, `detPag`, `tPag`, `xPag`, `vPag`. As seções 3.1.1 a 3.1.10 cobrem Chave de Acesso, Dados da NF-e, Emitente, Local de Retirada/Entrega, Fatura/Duplicatas, Produtos/Serviços, Inf. Complementares, Reservado ao Fisco, Transportador — nenhuma para pagamento.
+- A **[NT 2016.002](https://www.nfe.fazenda.gov.br/portal/exibirArquivo.aspx?conteudo=tQNDQOeNeyI%3D)** (v1.50, em produção desde 2018) tornou o grupo `<pag>` obrigatório no XML da NF-e. O **Manual do DANFE NFC-e** (MOC 7.0 Anexo III, separado) mandou exibir o bloco no cupom da NFCe — mas isso é NFCe (modelo 65), não NF-e (modelo 55).
+- Para **DANFE de NF-e modelo 55**, o bloco "Forma de Pagamento" é **convenção universal de mercado** (TOTVS, SAP, SmartGo, eMissor, demais renderers da indústria), não mandato literal do MOC. Receptores fiscais e contadores esperam ver esse bloco; a ausência gera dúvida sobre a integridade da NF-e (foi o que motivou a demanda do cliente Revenda Mais).
+
+**Stakeholders**
+
+- Cliente **Revenda Mais** (relator, via @Carolina Fagundes em Microsoft Teams 2026-05-27, invoice de referência `9175b02ac0cf4ed898025c4bad09e2fe`)
+- Consumidores externos do `nfe/DanfeSharp` (Library NuGet/fork interno do NFe.io)
+- Receptores das DANFEs (varejistas, contadores, fiscais)
+
+**Constraints**
+
+- Manter compatibilidade total: DANFE sem `<pag>` no XML deve renderizar idêntica ao estado atual (zero regressão visual em emitentes que ainda não usam o grupo `<pag>` ou que emitem `tPag=90` "Sem Pagamento").
+- Nada de breaking change na API pública (`Danfe.GerarPdf`, `DanfeViewModel.Pagamento`).
+- Mudanças confinadas ao renderer + ao schema + ao viewmodel; XML/parser/emissão não mudam.
+- Sem dependências externas novas.
+- Schema XML deve aceitar `<pag>` ausente (caso de NF-e antiga, anterior à NT 2016.002, ainda parseável).
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Bloco visual "FORMA DE PAGAMENTO" passa a aparecer na DANFE quando o XML traz `<pag><detPag>` preenchido, com tabela contendo cabeçalho "FORMA PAGAMENTO" + "VALOR" e uma linha por `detPag`.
+- Mapeamento confiável de `tPag` numérico para descrição legível (`01 → "Dinheiro"`, `03 → "Cartão de Crédito"`, ..., `99 → "Outros"`) usando o `DescriptionAttribute` já presente no enum.
+- `tPag=99` (Outros) mostra o conteúdo de `xPag` na coluna FORMA PAGAMENTO (ex.: "RECURSOS PROPRIOS" do caso Revenda Mais).
+- Quando `xPag` está preenchido mesmo com `tPag` conhecido (caso atípico mas permitido pelo schema), prevalece o `xPag` (mais específico que a descrição genérica do `tPag`).
+- Valor formatado em moeda brasileira (`R$ 48.000,00`) com separador de milhar e duas casas decimais.
+- DANFE sem `<pag>` no XML continua renderizando idêntica (bloco omitido).
+- Cobertura por testes unitários nos cenários acima.
+
+**Non-Goals:**
+
+- Não renderizar subgrupos `<card>` (CNPJ adquirente, bandeira, autorização) — só FORMA + VALOR nesta change.
+- Não cobrir DANFE NFCe (modelo 65) — esse já tem manual próprio (MOC 7.0 Anexo III) e renderer separado (`DanfeNFC` em DanfeSharp).
+- Não mudar o XML schema da NF-e nem o parser.
+- Não tratar o campo `<vTroco>` na primeira iteração (mais relevante para NFCe).
+- Não criar UI para configurar layout (cores, fontes) — segue o estilo dos blocos existentes.
+
+## Decisions
+
+### Decision 1: Adicionar `xPag` ao schema, ao ViewModel e popular no Creator
+
+**Escolha:** adicionar a tag `xPag` (string opcional) à classe `detPag` em `ProcNFe.cs`, adicionar propriedade `Descricao` (string opcional) ao `DetalheViewModel` em `PagamentoViewModel.cs`, e ajustar `DanfeViewModelCreator.cs:328` para `detalhe.Descricao = detPag.xPag`.
+
+**Alternativa rejeitada:** ignorar `xPag` e renderizar sempre a descrição genérica do `[Description]` do enum `FormaPagamento`. Rejeitada porque perderíamos o caso `tPag=99` ("Outros") — o XML diz "RECURSOS PROPRIOS" mas o DANFE mostraria só "Outros", esvaziando a informação. A própria spec da NF-e (campo YA03 — `xPag`) existe exatamente para esse caso.
+
+### Decision 2: Renderer como `BlocoBase` (não `ElementoBase`) seguindo o padrão dos blocos do DANFE
+
+**Escolha:** criar `DanfeSharp/Blocos/BlocoFormaPagamento.cs` herdando de `BlocoBase`, com `Cabecalho = "Forma de Pagamento"`, `Posicao = PosicaoBloco.Topo` (alinhado pra esquerda como blocos finais), e usando `AdicionarLinhaCampos()` para cada `DetalheViewModel`. Cada linha tem 2 campos: `FORMA PAGAMENTO` (descrição) + `VALOR` (numérico, com helpers de moeda).
+
+**Alternativa considerada e rejeitada:** usar `ElementoBase` + objeto `Tabela` (padrão de `TabelaProdutosServicos`). Rejeitada porque:
+- `TabelaProdutosServicos` é caso especial: tem 15 colunas, layout horizontal complexo, e ainda é inserido fora do `AdicionarBloco<>` em `Danfe.cs:141`. Fugir desse molde rico em hooks não simplifica o caso simples de pagamento.
+- Os outros blocos (`BlocoCalculoImposto`, `BlocoDuplicataFatura`, `BlocoTransportador`) usam `BlocoBase` + `AdicionarLinhaCampos()` e o resultado visual é consistente com o resto da DANFE.
+- `BlocoBase` já integra com o `AdicionarBloco<T>()` em `Danfe.cs` — basta uma linha pra inserir no fluxo.
+
+### Decision 3: Posicionar o bloco entre `BlocoCalculoImposto` e `BlocoTransportador`
+
+**Escolha:** inserir `AdicionarBloco<BlocoFormaPagamento>()` em `Danfe.cs:71` (entre a linha do `BlocoCalculoImposto` e a do `BlocoTransportador`). Ordem resultante:
+
+1. IdentificacaoEmitente
+2. DestinatarioRemetente
+3. LocalRetirada / LocalEntrega (opcionais)
+4. DuplicataFatura
+5. CalculoImposto
+6. **FormaPagamento ← novo**
+7. Transportador
+8. DadosAdicionais
+9. (CalculoIssqn, condicional)
+
+**Alternativa considerada:** inserir depois de `BlocoTransportador`. Rejeitada porque visualmente, na maioria das DANFEs comerciais que vi referenciadas, a forma de pagamento aparece próxima dos blocos de cálculo (antes do transportador) — segue a lógica de "tudo relacionado a valores fiscais junto, transportador é logística".
+
+**Alternativa considerada:** flag de configuração para escolher a posição. Rejeitada por overengineering — uma posição razoável + sólida é melhor que duas opções configuráveis.
+
+### Decision 4: Inserir o bloco APENAS quando o `ViewModel.Pagamento` tiver itens
+
+**Escolha:** o construtor do `BlocoFormaPagamento` valida `ViewModel.Pagamento?.Any(p => p.DetalhePagamento?.Any() == true) == true`; se falso, nenhuma linha é adicionada e o bloco renderiza vazio (height efetivo ≈ 0). Alternativamente, condicionar o `AdicionarBloco<BlocoFormaPagamento>()` em `Danfe.cs` a `ViewModel.Pagamento?.Any() == true`. Ambas estratégias são aceitáveis; a primeira é mais robusta (o bloco se auto-omitir não corrompe o fluxo se for chamado em um caso de edge), a segunda é mais econômica (não cria objeto desnecessariamente).
+
+**Decisão final:** auto-omitir dentro do construtor (estratégia 1) + condicional em `Danfe.cs` adicionalmente (estratégia 2) — defense in depth.
+
+### Decision 5: Mapeamento `tPag → descrição` via `DescriptionAttribute` do enum
+
+**Escolha:** criar helper estático `FormaPagamentoExtensions.GetDescricao(FormaPagamento)` (ou método em outro lugar pertinente) que retorna o conteúdo de `[Description]` por reflexão. O cabeçalho da célula "FORMA PAGAMENTO" usa `xPag` se presente, senão chama esse helper.
+
+**Alternativa rejeitada:** switch literal mapeando código → string. Rejeitada porque duplica info já no enum, e o `DescriptionAttribute` é a convenção C# para descrições. Também: se a NT adicionar `fp20` (novo meio de pagamento), basta acrescentar uma linha no enum com `[Description]`; o helper continua funcionando.
+
+### Decision 6: Sem feature flag
+
+A correção é puramente aditiva (sem mudança em comportamento existente). Não há cenário onde um consumidor queira a DANFE sem o bloco quando o XML tem `<pag>`. Logo, sem flag de configuração para isso. Em algum momento, se aparecer demanda do tipo "quero a DANFE minimalista sem pagamento", podemos adicionar via `DanfeViewModel.ExibirPagamento` (default `true`).
+
+## Risks / Trade-offs
+
+- **[Risk]** A coluna VALOR do novo bloco pode quebrar o layout em folha com muito pouco espaço vertical disponível (NF-e com muitos itens de produto + muitos detPag). → **Mitigation:** o `BlocoBase` lida com paginação no engine PDF existente; testar com fixtures que tenham 10+ detPag pra confirmar o comportamento. Adicionar fixture XML se necessário.
+- **[Risk]** Schema `detPag.xPag` adicionado pode quebrar parse de XMLs antigos sem `<xPag>` — improvável (XmlSerializer trata elementos faltantes como null por padrão), mas testar com XML pre-NT-2016.002 (provavelmente `v3.10_Retrato.xml` ou `v1.xml` em `DanfeSharp.Test/Xml/NFe/`). → **Mitigation:** `xPag` declarado como `string?`, sem `[XmlElement(IsRequired = true)]`. Teste de regressão garante que XMLs sem `<pag>` continuam parseando.
+- **[Trade-off]** Inserir o bloco SEMPRE no fluxo (mesmo quando vazio) gasta nanossegundos extras na construção do `Danfe`. → Aceito; o gain de robustez supera.
+- **[Trade-off]** Usando `DescriptionAttribute` via reflexão para `tPag → descrição` tem custo (mínimo) por linha. → Aceito; é a forma idiomática em C# e o número de detPag por NF-e é tipicamente ≤ 5.
+- **[Risk]** Tabela `tPag` pode ser atualizada por NT futura (NT 2020.001 já adicionou códigos 16-19). → **Mitigation:** o enum em `ProcNFe.cs:1020` já está atualizado até NT 2020.001; mudanças futuras pedirão acréscimo simples (1 valor + 1 `[Description]`).
+
+## Migration Plan
+
+1. Adicionar `xPag` (string opcional) à classe `detPag` em `ProcNFe.cs`.
+2. Adicionar propriedade `Descricao` (string opcional) ao `DetalheViewModel` em `PagamentoViewModel.cs`.
+3. Atualizar `DanfeViewModelCreator.cs:328` para popular `detalhe.Descricao = detPag.xPag`.
+4. Criar helper `FormaPagamentoExtensions.GetDescricao(FormaPagamento)` (provavelmente em `DanfeSharp/Esquemas/ProcNFe.cs` perto do enum, ou em `Modelo/` como classe de extensão).
+5. Criar `DanfeSharp/Blocos/BlocoFormaPagamento.cs` herdando `BlocoBase`, com `Cabecalho = "Forma de Pagamento"` e iteração sobre `ViewModel.Pagamento[].DetalhePagamento`.
+6. Inserir `AdicionarBloco<BlocoFormaPagamento>()` em `Danfe.cs` entre `BlocoCalculoImposto` e `BlocoTransportador`.
+7. Adicionar testes unitários cobrindo os 5 cenários da spec.
+8. Atualizar snapshots/fixtures de PDF em `DanfeSharp.Test/bin/Debug/Output/DeXml/` (revisar diff visual: `v4_ComLocalEntrega.pdf` provavelmente passa a exibir o bloco se a fixture XML tiver `<pag>`).
+9. PR em draft → review → merge → release minor do pacote (se aplicável).
+
+**Rollback:** se houver regressão, revert do PR. Não há migração de dados nem state persistido.
+
+## Open Questions
+
+- **xPag prevalece sobre descrição do enum?** Tenho que confirmar com Carolina/cliente Revenda Mais se quando ambos estão preenchidos (`tPag=01` "Dinheiro" + `xPag="Pagamento à vista"`) o renderer deve mostrar `xPag` ou ignorar. Default da spec: prevalece `xPag` (mais específico). Reabrir se a Revenda Mais quiser o oposto.
+- **Trato `<vTroco>` nesta change?** Atualmente `Troco` está no `PagamentoViewModel`. Não há mandato literal para mostrar troco no DANFE NF-e (MOC silencia; é convenção mais forte em NFCe). Decisão atual: **não exibir** troco nesta change (out of scope); reavaliar se cliente pedir.
+- **Largura da coluna VALOR é suficiente para R$ XX.XXX.XXX,XX?** Validar visualmente com fixtures com valores grandes (R$ 1.000.000,00 e acima) na fase de testes.
+- **DANFE em paisagem (`Orientacao.Paisagem`) acomoda o novo bloco?** Validar visualmente; ajustar `Posicao` ou `Estilo` se necessário.
+- **Helper `GetDescricao` deve ficar em `DanfeSharp.Esquemas` ou `DanfeSharp.Modelo`?** Decisão tátil — resolver na implementação. Provavelmente `Modelo` (não polui o schema layer).

--- a/openspec/changes/archive/2026-05-28-add-danfe-payment-block/proposal.md
+++ b/openspec/changes/archive/2026-05-28-add-danfe-payment-block/proposal.md
@@ -1,0 +1,43 @@
+## Why
+
+O `nfe/DanfeSharp` não renderiza nenhum bloco visual de forma de pagamento na DANFE de NF-e modelo 55, mesmo quando o XML traz o grupo `<pag><detPag>` preenchido — situação tornada universal a partir da NT 2016.002 / v4.0 que tornou `<pag>` obrigatório na NF-e. Cliente Revenda Mais (issue [#39](https://github.com/nfe/DanfeSharp/issues/39), umbrella [#37](https://github.com/nfe/DanfeSharp/issues/37)) reportou que o XML traz `<pag><detPag><tPag>99</tPag><xPag>RECURSOS PROPRIOS</xPag><vPag>48000.00</vPag></detPag></pag>` mas a DANFE termina em "DADOS DOS PRODUTOS / SERVIÇOS" sem exibir a forma de pagamento — visualmente inconsistente com o que receptores fiscais e contadores esperam ver em NF-e modelo 55 emitidas após 2018. **Importante: o MOC 7.0 Anexo II (Manual de Especificações Técnicas do DANFE) não tem seção dedicada a forma de pagamento — verifiquei literalmente o PDF do CONFAZ em 2026-05-28; a renderização desse bloco em DANFE de NF-e é convenção universal de mercado (TOTVS, SAP, SmartGo, eMissor), análoga ao caso do change [`fix-danfe-csosn-rendering`](../archive/2026-05-28-fix-danfe-csosn-rendering/proposal.md). A NT 2016.002 obrigou o grupo `<pag>` no XML; o manual do DANFE NFC-e (modelo 65) mandou exibir o bloco no cupom; para NF-e modelo 55 o uso visual é convenção consolidada, não mandato literal.
+
+O fork `nfe/DanfeSharp` descende do upstream `SilverCard/DanfeSharp` que precede a NT 2016.002 — o bloco provavelmente nunca foi implementado neste renderer. Curiosamente, **o trabalho de schema XML + ViewModel já está parcialmente feito** (classes `pag`/`detPag`/`FormaPagamento` em `ProcNFe.cs`, `PagamentoViewModel`/`DetalheViewModel` em `Modelo/`, e o `DanfeViewModelCreator` já popula a propriedade `model.Pagamento`) — falta apenas o campo `xPag`, o bloco visual e a inserção no fluxo da DANFE.
+
+## What Changes
+
+- Adicionar campo `xPag` (descrição da forma de pagamento, usado quando `tPag=99` ou para complementar `tPag` conhecidos) ao schema XML `detPag` em `DanfeSharp/Esquemas/ProcNFe.cs` e ao `DetalheViewModel` em `DanfeSharp/Modelo/PagamentoViewModel.cs`.
+- `DanfeSharp/Modelo/DanfeViewModelCreator.cs` passa a popular `detalhe.Descricao` (mapeada de `detPag.xPag`).
+- Criar novo bloco renderer `DanfeSharp/Blocos/BlocoFormaPagamento.cs` que desenha uma tabela com cabeçalho "FORMA DE PAGAMENTO" e colunas "FORMA PAGAMENTO" + "VALOR", uma linha por `DetalheViewModel`.
+- Mapeamento de `tPag` numérico para descrição legível usa o `DescriptionAttribute` já presente no enum `FormaPagamento` (`[Description("Dinheiro")]`, `[Description("Cartão de Crédito")]`, etc.). Quando `tPag=99` ("Outros"), o renderer exibe o conteúdo de `xPag` no lugar; quando `xPag` está presente mesmo com tPag conhecido, prevalece `xPag` (mais específico).
+- Valor formatado em moeda brasileira (`R$ 48.000,00`) usando os helpers de formatação existentes no projeto.
+- Inserir o bloco no fluxo de renderização em `DanfeSharp/Danfe.cs`, posicionado **antes do bloco Transportador** (ordem visual convencional: Produtos → Cálculo do Imposto → Forma de Pagamento → Transportador → Dados Adicionais).
+- DANFE de NF-e sem o grupo `<pag>` no XML continua renderizando idêntica — o bloco é omitido (não desenha nada se `ViewModel.Pagamento` está vazio).
+- Cobertura de testes unitários cobrindo: (a) tPag numérico mapeado via Description, (b) tPag=99 + xPag, (c) múltiplos detPag, (d) XML sem `<pag>`, (e) valor formatado em R$.
+- **Nenhuma mudança de comportamento** para emitentes que hoje geram DANFEs sem `<pag>` no XML.
+
+## Capabilities
+
+### New Capabilities
+
+- `danfe-payment-block`: regras de renderização do bloco "FORMA DE PAGAMENTO" no DANFE de NF-e modelo 55 — incluindo schema do grupo `<pag>` (campos `tPag`/`xPag`/`vPag`/`vTroco`), mapeamento `tPag → descrição`, tratamento de tPag=99 (Outros), tabela visual (cabeçalho + colunas FORMA PAGAMENTO + VALOR + 1 linha por detPag), e omissão graciosa quando o XML não tem `<pag>`.
+
+### Modified Capabilities
+
+_Nenhuma — a spec `danfe-icms-column` (do change anterior, #38) não é tocada por esta change._
+
+## Impact
+
+- **Código afetado** (a confirmar no design):
+  - `DanfeSharp/Esquemas/ProcNFe.cs` — adicionar `xPag` à class `detPag` (string, opcional, mapeada com `[XmlElement("xPag")]`)
+  - `DanfeSharp/Modelo/PagamentoViewModel.cs` — adicionar `Descricao` em `DetalheViewModel`
+  - `DanfeSharp/Modelo/DanfeViewModelCreator.cs` — popular `detalhe.Descricao = detPag.xPag` (em torno da linha 326-329, onde já popula `FormaPagamento` e `Valor`)
+  - `DanfeSharp/Blocos/BlocoFormaPagamento.cs` — **arquivo novo**, segue padrão dos outros blocos (herda `ElementoBase`, tem `Tabela`, override `Draw`)
+  - `DanfeSharp/Danfe.cs` — inserir `AdicionarBloco<BlocoFormaPagamento>()` no fluxo do construtor, antes do `BlocoTransportador`
+  - `DanfeSharp.Test/PagamentoTests.cs` (ou similar) — arquivo novo de testes; ajustar `DanfeSharp.Test.csproj` para incluir
+- **APIs públicas**: aditivas. Novas propriedades em `DetalheViewModel` (`Descricao`), comportamento novo de renderização. Sem breaking changes.
+- **Backward compatibility**: total. DANFE sem `<pag>` no XML renderiza igual ao estado atual.
+- **Dependências externas**: nenhuma nova.
+- **Cliente impactado positivamente**: Revenda Mais (escopo direto) e qualquer outro emitente cujas DANFEs sejam recebidas por contrapartes que esperam ver o bloco de forma de pagamento.
+- **Não impacta**: geração do XML, outras colunas/blocos da DANFE, DANFE NFCe (modelo 65), DANFE de MDF-e, DANFE de CT-e, Nota de Crédito por Recusa Parcial (essa renderização adicional é independente — `<pag>` pode estar presente ou não em NFCredito).
+- **Issue mãe**: nfe/DanfeSharp#37; issues irmãs: nfe/DanfeSharp#38 (já mergeada — change `fix-danfe-csosn-rendering`), nfe/DanfeSharp#40.

--- a/openspec/changes/archive/2026-05-28-add-danfe-payment-block/specs/danfe-payment-block/spec.md
+++ b/openspec/changes/archive/2026-05-28-add-danfe-payment-block/specs/danfe-payment-block/spec.md
@@ -1,0 +1,139 @@
+## ADDED Requirements
+
+> **Base normativa:** o quadro "Forma de Pagamento" **não é literalmente prescrito** pelo [MOC 7.0 — Anexo II](https://www.confaz.fazenda.gov.br/legislacao/arquivo-manuais/moc7-anexo-ii-manual-especificacoes-tecnicas-danfe-codigo-barras.pdf) (Manual de Especificações Técnicas do DANFE para NF-e modelo 55) — verifiquei literalmente o PDF em 2026-05-28: zero menções a `pagamento`/`detPag`/`tPag`/`xPag`. A obrigatoriedade está no XML, via [NT 2016.002 v1.50](https://www.nfe.fazenda.gov.br/portal/exibirArquivo.aspx?conteudo=tQNDQOeNeyI%3D), que tornou o grupo `<pag>` exigido na NF-e (em produção desde 2018). O bloco visual no DANFE NF-e modelo 55 é **convenção universal de mercado** (TOTVS, SAP, SmartGo, eMissor) que receptores fiscais e contadores esperam ver. A spec abaixo formaliza essa convenção para o `nfe/DanfeSharp`.
+
+### Requirement: Schema parsing of `<pag>/<detPag>/xPag` group
+
+O renderer SHALL deserializar o grupo `<pag><detPag>` do XML da NF-e incluindo a tag `<xPag>` (descrição livre da forma de pagamento). A propriedade `detPag.xPag` deve ser opcional — XMLs anteriores à NT 2016.002 ou que não tenham `<xPag>` continuam parseando sem erro.
+
+#### Scenario: XML com `<xPag>` preenchido
+
+- **GIVEN** um XML com `<pag><detPag><tPag>99</tPag><xPag>RECURSOS PROPRIOS</xPag><vPag>48000.00</vPag></detPag></pag>`
+- **WHEN** o XML é deserializado pelo `ProcNFeSerializer`
+- **THEN** `detPag.xPag == "RECURSOS PROPRIOS"`, `detPag.tPag == FormaPagamento.fpOutros`, `detPag.vPag == 48000.00m`
+
+#### Scenario: XML sem `<xPag>`
+
+- **GIVEN** um XML com `<pag><detPag><tPag>01</tPag><vPag>100.00</vPag></detPag></pag>` (sem `<xPag>`)
+- **WHEN** o XML é deserializado
+- **THEN** `detPag.xPag == null` (ou string vazia), `detPag.tPag == FormaPagamento.fpDinheiro`, `detPag.vPag == 100.00m`
+
+#### Scenario: XML sem grupo `<pag>` (NF-e antiga ou v4.0+ com `tPag=90`)
+
+- **GIVEN** um XML de NF-e que não contém o elemento `<pag>` (ex.: fixture `v3.10_Retrato.xml`)
+- **WHEN** o XML é deserializado
+- **THEN** `infNFe.pag == null` (ou lista vazia) — sem exceção lançada
+
+### Requirement: ViewModel exposes `Descricao` mapped from `xPag`
+
+O `DanfeSharp.Modelo.DetalheViewModel` SHALL expor uma propriedade pública `Descricao` (`string`, opcional) que reflete o conteúdo da tag XML `<xPag>`. O `DanfeViewModelCreator` SHALL populá-la quando o XML for processado.
+
+#### Scenario: Producer popula Descricao
+
+- **GIVEN** um XML com `<detPag><tPag>99</tPag><xPag>BOLETO BB</xPag><vPag>500.00</vPag></detPag>`
+- **WHEN** `DanfeViewModelCreator.CriarDeStringXml(xml)` é chamado
+- **THEN** o `DanfeViewModel.Pagamento[0].DetalhePagamento[0].Descricao == "BOLETO BB"`
+
+#### Scenario: Producer normaliza string vazia para null
+
+- **GIVEN** um XML com `<xPag></xPag>` (elemento presente mas vazio)
+- **WHEN** o XML é processado
+- **THEN** `DetalheViewModel.Descricao == null` (não string vazia) — para consistência com a regra de "ausência" em outros campos do projeto
+
+### Requirement: Render block "FORMA DE PAGAMENTO" when `Pagamento` is populated
+
+A DANFE de NF-e modelo 55 SHALL renderizar um bloco com cabeçalho "Forma de Pagamento" quando `ViewModel.Pagamento` contém pelo menos um `DetalheViewModel`. O bloco SHALL aparecer entre o "Cálculo do Imposto" e o "Transportador" no fluxo visual da DANFE. Cada `DetalheViewModel` SHALL ocupar uma linha com duas células: **FORMA PAGAMENTO** (descrição) e **VALOR** (numérico em moeda brasileira).
+
+#### Scenario: NF-e com 1 detPag
+
+- **GIVEN** uma NF-e com `Pagamento = [ { DetalhePagamento = [ DetalheViewModel { FormaPagamento=fpOutros, Descricao="RECURSOS PROPRIOS", Valor=48000.00m } ] } ]`
+- **WHEN** a DANFE é renderizada
+- **THEN** aparece um bloco com cabeçalho "Forma de Pagamento" contendo 1 linha: "RECURSOS PROPRIOS" + "R$ 48.000,00"
+
+#### Scenario: NF-e com múltiplos detPag
+
+- **GIVEN** uma NF-e com 3 itens em `DetalhePagamento`: (Dinheiro, R$ 100), (Cartão de Crédito, R$ 50), (PIX [tPag=17], R$ 25)
+- **WHEN** a DANFE é renderizada
+- **THEN** o bloco "Forma de Pagamento" exibe 3 linhas, uma para cada `DetalheViewModel`, na ordem do XML
+
+### Requirement: Cell formatting for FORMA PAGAMENTO column
+
+A célula da coluna "FORMA PAGAMENTO" SHALL conter o conteúdo de `DetalheViewModel.Descricao` quando preenchido; caso contrário, a descrição derivada do `[DescriptionAttribute]` do enum `FormaPagamento` (ex.: `fpDinheiro → "Dinheiro"`, `fpCartaoCredito → "Cartão de Crédito"`, `fpOutros → "Outros"`).
+
+#### Scenario: Descricao prevalece sobre descrição do enum
+
+- **GIVEN** `DetalheViewModel { FormaPagamento=fpCartaoCredito, Descricao="VISA 4× 2,5%" }`
+- **WHEN** a célula FORMA PAGAMENTO é renderizada
+- **THEN** o conteúdo da célula é "VISA 4× 2,5%" (não "Cartão de Crédito")
+
+#### Scenario: Sem Descricao, usa enum
+
+- **GIVEN** `DetalheViewModel { FormaPagamento=fpDinheiro, Descricao=null }`
+- **WHEN** a célula FORMA PAGAMENTO é renderizada
+- **THEN** o conteúdo é "Dinheiro" (derivado do `[Description]` do enum)
+
+#### Scenario: tPag=99 sempre exige Descricao para ser informativo
+
+- **GIVEN** `DetalheViewModel { FormaPagamento=fpOutros, Descricao="RECURSOS PROPRIOS" }`
+- **WHEN** a célula FORMA PAGAMENTO é renderizada
+- **THEN** o conteúdo é "RECURSOS PROPRIOS"
+
+#### Scenario: tPag=99 sem Descricao usa fallback genérico
+
+- **GIVEN** `DetalheViewModel { FormaPagamento=fpOutros, Descricao=null }` (XML mal-formado mas possível)
+- **WHEN** a célula FORMA PAGAMENTO é renderizada
+- **THEN** o conteúdo é "Outros" (descrição do enum) — sem null reference
+
+### Requirement: Cell formatting for VALOR column
+
+A célula da coluna "VALOR" SHALL renderizar `DetalheViewModel.Valor` em formato numérico brasileiro: separador de milhar `.`, separador decimal `,`, duas casas decimais sempre. **Sem prefixo `R$`** — segue a convenção do `DanfeSharp` para campos numéricos dentro de blocos (`BlocoCalculoImposto`, `BlocoCalculoIssqn` também usam apenas o número formatado, sem `R$`). O prefixo `R$` na DANFE aparece apenas em totalizadores específicos (cabeçalho/canhoto), não em blocos de campos.
+
+#### Scenario: Valor inteiro
+
+- **GIVEN** `Valor = 48000.00m`
+- **WHEN** a célula VALOR é renderizada
+- **THEN** o conteúdo é `48.000,00`
+
+#### Scenario: Valor com decimais
+
+- **GIVEN** `Valor = 123.45m`
+- **WHEN** a célula VALOR é renderizada
+- **THEN** o conteúdo é `123,45`
+
+#### Scenario: Valor grande
+
+- **GIVEN** `Valor = 1234567.89m`
+- **WHEN** a célula VALOR é renderizada
+- **THEN** o conteúdo é `1.234.567,89`
+
+### Requirement: Graceful omission when `<pag>` is absent
+
+A DANFE SHALL NOT renderizar o bloco "Forma de Pagamento" quando o XML não contém o grupo `<pag>` ou quando o grupo está presente mas sem nenhum `<detPag>`. A ausência do bloco NÃO SHALL afetar o layout dos demais blocos (Transportador continua aparecendo na posição atual; cálculo de imposto também).
+
+#### Scenario: NF-e antiga sem `<pag>`
+
+- **GIVEN** uma NF-e cujo XML é v3.10 sem grupo `<pag>` (ex.: fixture `v3.10_Retrato.xml`)
+- **WHEN** a DANFE é renderizada
+- **THEN** o PDF gerado é idêntico ao gerado antes desta change (zero regressão visual)
+
+#### Scenario: NF-e com `<pag>` vazio
+
+- **GIVEN** uma NF-e com `<pag></pag>` (presente mas vazio — não conforme, mas possível por bug do emissor)
+- **WHEN** a DANFE é renderizada
+- **THEN** o bloco "Forma de Pagamento" é omitido (não desenha cabeçalho nem tabela)
+
+### Requirement: Helper `FormaPagamento.GetDescricao()` reusable across the project
+
+O renderer SHALL expor um helper público (extension method ou static helper) que retorna a descrição legível de um valor `FormaPagamento` lendo o `DescriptionAttribute` do enum por reflexão. Esse helper SHALL retornar uma string não-vazia para todos os valores definidos no enum (`01` a `19`, `90`, `99`).
+
+#### Scenario: Descrição de cada valor do enum
+
+- **GIVEN** o enum `FormaPagamento` com `[Description("Dinheiro")]` em `fpDinheiro`
+- **WHEN** `FormaPagamentoExtensions.GetDescricao(FormaPagamento.fpDinheiro)` é chamado
+- **THEN** retorna `"Dinheiro"`
+
+#### Scenario: Helper não lança em valor desconhecido
+
+- **GIVEN** um valor inteiro `(FormaPagamento)42` (fora do enum, caso de XML com novo código antes do enum ser atualizado)
+- **WHEN** o helper é chamado
+- **THEN** retorna `""` (string vazia) ou o código numérico como string — sem exceção

--- a/openspec/changes/archive/2026-05-28-add-danfe-payment-block/tasks.md
+++ b/openspec/changes/archive/2026-05-28-add-danfe-payment-block/tasks.md
@@ -1,0 +1,74 @@
+## 1. Investigação de uso externo (pre-flight)
+
+- [ ] 1.1 Buscar consumidores internos do NFe.io que usam `DanfeViewModel.Pagamento` ou `DetalheViewModel` para garantir que adicionar `Descricao` ao `DetalheViewModel` não conflita com nada existente. _(Manual — fora do working tree atual.)_
+- [ ] 1.2 Confirmar com cliente Revenda Mais (via @Carolina Fagundes) duas dúvidas: (a) quando `tPag=01` (Dinheiro) e `xPag="Pagamento à vista"` ambos vêm preenchidos, mostrar `xPag` (mais específico) ou ignorar? (b) Largura aceitável para a coluna VALOR quando aparece R$ XX.XXX.XXX,XX. _(Default da spec: `xPag` prevalece; largura ajustável depois conforme feedback.)_
+
+## 2. Schema XML — `ProcNFe.cs`
+
+- [x] 2.1 Adicionada propriedade `public string xPag { get; set; }` à classe `detPag` em `ProcNFe.cs:411`, com XML doc YA03.
+- [x] 2.2 Deserialização aceita XMLs sem `<xPag>` (`XmlSerializer` retorna `null`) — confirmado pelo teste `Schema_XmlSemXPag_RetornaNull`.
+- [x] 2.3 `xPag` sem `[XmlElement(IsRequired=true)]` (opcional).
+
+## 3. ViewModel — `PagamentoViewModel.cs`
+
+- [x] 3.1 Adicionada `public string Descricao { get; set; }` ao `DetalheViewModel` em `PagamentoViewModel.cs:28`.
+- [x] 3.2 XML doc do `Descricao` documenta "Quando preenchida, prevalece sobre a descrição padrão do enum FormaPagamento".
+
+## 4. Producer — `DanfeViewModelCreator.cs`
+
+- [x] 4.1 Adicionado `detalhe.Descricao = String.IsNullOrEmpty(detPag.xPag) ? null : detPag.xPag;` em `CreateFromProcNFCe`.
+- [x] 4.2 **Bug raiz adicional descoberto e corrigido**: a população do grupo `<pag>` estava só em `CreateFromProcNFCe` (NFC-e modelo 65) — faltava em `CreateFromProcNFe` (NF-e modelo 55, escopo desta change). Adicionado o foreach `infNfe.pag` em `CreateFromProcNFe` antes do `return model;`. Sem essa correção o bloco renderer nunca dispararia. Cobertura por `IntegracaoPagamentoNFe.V4ComLocalEntrega_PopulaPagamentoDoGrupoPag`.
+- [x] 4.3 Tratamento defensivo de null em `infNfe.pag` e `pag.detPag` (testado por `V3_10Retrato_SemPag_NaoQuebraEPagamentoFicaVazio`).
+
+## 5. Helper — `FormaPagamentoExtensions`
+
+- [x] 5.1 Criado `DanfeSharp/Modelo/FormaPagamentoExtensions.cs` com `public static string GetDescricao(this FormaPagamento fp)`.
+- [x] 5.2 Retorna `string.Empty` para enum value inválido (testado por `GetDescricao_ValorInvalido_RetornaStringVazia`).
+- [x] 5.3 Cobertura: testes `GetDescricao_*` para Dinheiro / CartaoCredito / CartaoDebito / Outro / PIX + caso inválido. **Achado**: existem 2 enums `FormaPagamento` no projeto (em `Enums.cs` e em `ProcNFe.cs`); helper atual opera no `DanfeSharp.FormaPagamento` (Modelo/Enums.cs), que é o usado por `DetalheViewModel.FormaPagamento`.
+
+## 6. Renderer — `BlocoFormaPagamento.cs`
+
+- [x] 6.1 Criado `DanfeSharp/Blocos/BlocoFormaPagamento.cs` herdando `BlocoBase`, seguindo padrão de `BlocoCalculoImposto`.
+- [x] 6.2 `Cabecalho => "Forma de Pagamento"`, `Posicao => PosicaoBloco.Topo`.
+- [x] 6.3 Iteração com `SelectMany` sobre `Pagamento[].DetalhePagamento`. Célula FORMA PAGAMENTO usa `d.Descricao ?? d.FormaPagamento.GetDescricao()`. Célula VALOR usa `ComCampoNumerico(...)` (sem prefixo `R$` — convenção do `BlocoCalculoImposto` & cia; spec atualizada para refletir).
+- [x] 6.4 Auto-omissão: early return quando `detalhes == null || detalhes.Count == 0`.
+- [x] 6.5 Suporta Retrato e Paisagem (herdado de `BlocoBase`).
+
+## 7. Sequência — `Danfe.cs`
+
+- [x] 7.1 Inserido `AdicionarBloco<BlocoFormaPagamento>()` em `Danfe.cs` entre `BlocoCalculoImposto` e `BlocoTransportador`.
+- [x] 7.2 Condicionado à `ViewModel.Pagamento != null && Pagamento.Any(p => p.DetalhePagamento?.Count > 0)` + `using System.Linq;` adicionado.
+
+## 8. Testes unitários
+
+- [x] 8.1 Criado `DanfeSharp.Test/FormaPagamentoTests.cs` (14 testes) cobrindo: helper para Dinheiro/CartaoCredito/CartaoDebito/Outro/PIX/inválido, schema parsing com/sem `<xPag>` (e `<xPag></xPag>` vazio), `DetalheViewModel.Descricao`, regra "Descricao prevalece sobre enum description". Aliases `FormaPagamentoVm`/`FormaPagamentoSchema` para desambiguar os 2 enums coexistentes.
+- [x] 8.2 Criado `IntegracaoPagamentoNFe` (2 testes) no mesmo arquivo cobrindo: NF-e v4 com `<pag>` popula `model.Pagamento` (regressão direta do bug raiz §4.2); NF-e v3.10 sem `<pag>` não quebra e mantém `Pagamento.Count == 0`. **Substitui o BlocoFormaPagamentoTests.cs originalmente planejado** — o renderer foi testado via DanfeXmlTests (integração end-to-end mais robusta que mockar PdfClown internals).
+- [x] 8.3 `DanfeSharp.Test.csproj` atualizado: `<Compile Include="FormaPagamentoTests.cs" />` + `<Reference Include="System.Xml" />` (necessário para `XmlSerializer` nos testes de schema parsing).
+- [x] 8.4 `dotnet build`: 0 erros. `dotnet vstest --TestCaseFilter:"FullyQualifiedName~FormaPagamento|FullyQualifiedName~IntegracaoPagamentoNFe"` → **16/16 aprovados**, 748 ms.
+- [x] 8.5 `dotnet vstest --TestCaseFilter:"FullyQualifiedName~DanfeXmlTests"` → **5/5 aprovados**, sem regressão. PDF re-renderizado de `v4_ComLocalEntrega.xml` exibe o novo bloco corretamente posicionado.
+
+## 9. Fixture XML (opcional, recomendado)
+
+- [x] 9.1-9.3 **Não necessário criar fixture nova**: descobri durante a implementação que as fixtures `v4_ComLocalEntrega.xml` e `v4_ComLocalRetirada.xml` **já têm grupo `<pag>` preenchido** (`<detPag><tPag>99</tPag><vPag>3977.00</vPag></detPag>`). O efeito da mudança já é coberto pelos `DanfeXmlTests.v4_ComLocalEntrega` e `.v4_ComLocalRetirada` existentes — eles renderizam o bloco novo automaticamente. Se algum dia quisermos cobrir caso com `<xPag>` preenchido + múltiplos `<detPag>`, basta criar essa fixture nova.
+
+## 10. Validação visual (manual, fora do CI)
+
+- [ ] 10.1 Gerar PDF da invoice de referência `9175b02ac0cf4ed898025c4bad09e2fe` (company `150a90afdf3e468f9feb7f8973707ce9` do cliente Revenda Mais). Confirmar visualmente que o bloco "Forma de Pagamento" aparece entre Cálculo do Imposto e Transportador, com `RECURSOS PROPRIOS / R$ 48.000,00`.
+- [ ] 10.2 Gerar PDFs antes/depois das fixtures `v4_ComLocalEntrega.xml` e `v4_ComLocalRetirada.xml`. Confirmar: (a) se essas fixtures têm `<pag>`, o bloco passa a aparecer; (b) se não têm, PDF é idêntico ao baseline.
+- [ ] 10.3 Tirar prints antes/depois e anexar no PR como evidência.
+
+## 11. Documentação e changelog
+
+- [x] 11.1 Repo não mantém CHANGELOG (confirmado em #38); doc fica no PR body.
+- [x] 11.2 XML doc em `BlocoFormaPagamento.cs` referencia `openspec/specs/danfe-payment-block/spec.md`. NT 2016.002 está citada no `proposal.md`/`design.md`/`spec.md`.
+
+## 12. PR e revisão
+
+- [ ] 12.1 PR body com link `Fixes #39`, screenshots antes/depois (do tasks §10.3), e nota sobre base normativa calibrada (MOC não manda, NT obrigou o XML, bloco visual é convenção).
+- [ ] 12.2 Solicitar review do @joaokita (co-assignee automático no `nfe/DanfeSharp`) + alguém fiscal-aware do time NFe.io.
+- [ ] 12.3 Após approval, retirar o draft e mergear (squash) em `main`.
+
+## 13. Arquivamento OpenSpec (post-merge)
+
+- [ ] 13.1 Após merge, rodar `openspec validate fix-danfe-csosn-rendering... err... add-danfe-payment-block` para confirmar consistência.
+- [ ] 13.2 Rodar `openspec archive add-danfe-payment-block -y` para mover a change para `openspec/changes/archive/` e promover os requirements ADDED para `openspec/specs/danfe-payment-block/spec.md`. Preencher o `Purpose` no spec.md (substituindo o boilerplate "TBD") com a base normativa.

--- a/openspec/changes/archive/2026-05-28-fix-danfe-csosn-rendering/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-28-fix-danfe-csosn-rendering/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-28

--- a/openspec/changes/archive/2026-05-28-fix-danfe-csosn-rendering/design.md
+++ b/openspec/changes/archive/2026-05-28-fix-danfe-csosn-rendering/design.md
@@ -1,0 +1,131 @@
+## Context
+
+DanfeSharp é um renderer de DANFE em C# (.NET) que carrega o XML da NF-e via `XmlSerializer` (`DanfeSharp.Esquemas.ProcNFe`) e o traduz para um modelo de apresentação (`DanfeSharp.Modelo.DanfeViewModel`) consumido por blocos de desenho que usam o PDF builder embutido. A coluna "O/CSOSN" do bloco `TabelaProdutosServicos` mostra **origem da mercadoria + código de tributação ICMS** (CST para Regime Normal, CSOSN para Simples Nacional).
+
+**Estado atual (bugs)**
+
+1. **`DanfeSharp/Modelo/DanfeViewModelCreator.cs:497`** — a montagem do valor da coluna usa concatenação de strings sem separador:
+   ```csharp
+   produto.OCst = icms.orig + icms.CST + icms.CSOSN;
+   ```
+   Como CST e CSOSN são mutuamente exclusivos (apenas um é preenchido por item), o resultado para um produto com `<orig>1</orig><CST>20</CST>` vira `"120"` em vez de `"1/20"`.
+
+2. **`DanfeSharp/Blocos/TabelaProdutosServicos.cs:25`** — o cabeçalho é decidido apenas pelo CRT do emitente:
+   ```csharp
+   String cabecalho4 = ViewModel.Emitente.CRT == "3" ? "O/CST" : "O/CSOSN";
+   ```
+   Se o XML do emitente não traz `<CRT>` (campo opcional em emissores antigos ou XMLs mal-formados), `Emitente.CRT` fica `null`, a comparação falha, e o cabeçalho cai em `"O/CSOSN"` mesmo quando os produtos do XML têm `<CST>` (Regime Normal). É o que provavelmente ocorreu nas DANFEs do cliente Revenda Mais.
+
+**Stakeholders**
+
+- Cliente **Revenda Mais** (relator, via @Carolina Fagundes em Microsoft Teams 2026-05-27)
+- Consumidores externos do `nfe/DanfeSharp` (Library NuGet/fork interno usado em outros produtos NFe.io)
+- Receptores das DANFEs (varejistas, contadores) que conferem código tributário visualmente
+
+**Constraints**
+
+- Manter compatibilidade de API pública (`Danfe.GerarPdf` e variantes); nada de breaking change para consumidores
+- Manter cobertura visual idêntica para DANFEs hoje renderizadas corretamente (regressão zero)
+- Mudanças confinadas ao renderer/viewmodel — XML schema e parser não mudam
+- Sem novas dependências; código C# .NET conforme padrão do projeto
+
+## Goals / Non-Goals
+
+**Goals:**
+- Coluna mostra origem e código tributário separados por `/` (ex.: `1/20`, `0/102`)
+- Cabeçalho mostra `O/CST` quando os itens do XML usam `<CST>` (Regime Normal) e `O/CSOSN` quando usam `<CSOSN>` (Simples Nacional)
+- Robustez contra `Emitente.CRT` ausente/inconsistente — derivar do conteúdo real dos itens é mais confiável que confiar só no campo do emitente
+- Quando `<orig>` está ausente: célula mostra só o código, sem barra solta no início
+- Backward compatibility do `ProdutoViewModel.OCst` (consumidores externos podem ler essa propriedade)
+
+**Non-Goals:**
+- Não tratar marca de cancelada (cabe em #40 / PR #8)
+- Não tratar bloco "FORMA DE PAGAMENTO" (cabe em #39)
+- Não mudar o XML schema ou parser do `ProcNFe.cs`
+- Não criar UI para configurar o separador (`/` é fixo, padrão MOC NF-e)
+- Não cobrir DANFE NFCe (modelo 65) — só modelo 55
+
+## Decisions
+
+### Decision 1: Derivar o cabeçalho do conteúdo dos itens, não do `Emitente.CRT`
+
+**Escolha:** o cabeçalho `O/CST` ou `O/CSOSN` é decidido inspecionando os itens da nota. Se qualquer item tem `Cst` não-vazio → `"O/CST"`; senão se qualquer item tem `Csosn` não-vazio → `"O/CSOSN"`; senão (XML sem ICMS estruturado) → `"O/CST"` como fallback determinístico (regime normal é a maioria).
+
+**Alternativa rejeitada:** continuar usando `Emitente.CRT == "3"`. Rejeitada porque `CRT` é vulnerável a:
+- XMLs antigos sem o campo
+- Erros de cadastro do emitente
+- Casos limítrofes (excesso de sublimite, CRT=2)
+
+A presença concreta de `<CST>` vs `<CSOSN>` nos itens **é o ground-truth** do regime tributário em vigor — o que o receptor da DANFE consegue conferir contra o XML.
+
+**Alternativa rejeitada:** usar ambos os campos `Cst` e `Csosn` numa lógica composta com `Emitente.CRT`. Rejeitada por complexidade desproporcional ao ganho.
+
+### Decision 2: Modelar `Origem`, `Cst` e `Csosn` como propriedades separadas em `ProdutoViewModel`, mantendo `OCst` por compat
+
+**Escolha:** adicionar três propriedades novas:
+```csharp
+public string Origem { get; set; }   // "0", "1", ..., "8" — pode ser null/empty
+public string Cst { get; set; }      // ex. "00", "10", "20", "40" — null se item é Simples
+public string Csosn { get; set; }    // ex. "102", "500" — null se item é Regime Normal
+```
+
+A propriedade `OCst` continua existindo (backward compat) mas passa a ser **calculada** com a regra: `Origem/Cst` ou `Origem/Csosn` separados por `/`, omitindo elementos vazios. Setter privado/interno; o producer (DanfeViewModelCreator) preenche as três propriedades brutas.
+
+**Alternativa rejeitada:** sobrescrever a fórmula de `OCst` direto sem expor `Origem`/`Cst`/`Csosn` separados. Rejeitada porque o renderer de cabeçalho (Decision 1) precisa olhar item-a-item para `Cst` vs `Csosn` — fica feio extrair isso de uma string concatenada.
+
+**Alternativa rejeitada:** deprecar `OCst` e usar só os três campos brutos. Rejeitada porque rompe compat de consumidores externos que talvez já leiam `OCst`.
+
+### Decision 3: Formato exato da célula e do cabeçalho
+
+**Base normativa**
+
+A coluna `CST` é **obrigatória** no quadro "Dados dos Produtos/Serviços" do DANFE, conforme [MOC 7.0 — Anexo II, §3.1.7](https://www.confaz.fazenda.gov.br/legislacao/arquivo-manuais/moc7-anexo-ii-manual-especificacoes-tecnicas-danfe-codigo-barras.pdf) (página 11). O domínio do campo `<orig>` (origem da mercadoria: 0–8) está definido no schema do XML, em [MOC 7.0 — Anexo I](https://www.confaz.fazenda.gov.br/legislacao/arquivo-manuais/moc7-anexo-i-leiaute-e-rv.pdf), grupo `<ICMS>`. **O MOC não manda literalmente o formato combinado `O/CST` com separador `/`** — esse é convenção de mercado universalmente adotada (TOTVS, SAP, SmartGo, eMissor, etc.) por compactação visual e familiaridade dos receptores fiscais. A correção deste change alinha o `nfe/DanfeSharp` com essa convenção, restaurando o comportamento que receptores fiscais esperam ver e mantendo origem + CST/CSOSN visualmente distinguíveis.
+
+**Célula** (na linha de cada produto):
+
+| `Origem` | `Cst` | `Csosn` | Resultado |
+|---|---|---|---|
+| `"1"` | `"20"` | `null` | `"1/20"` |
+| `"0"` | `null` | `"102"` | `"0/102"` |
+| `null` | `"20"` | `null` | `"20"` (sem barra solta) |
+| `null` | `null` | `"500"` | `"500"` |
+| `"1"` | `null` | `null` | `"1"` (raro, mas possível em XML inconsistente) |
+| `null` | `null` | `null` | `""` (vazio) |
+
+Regra: `string.Join("/", [Origem, Cst ?? Csosn].Where(s => !string.IsNullOrEmpty(s)))`.
+
+**Cabeçalho** (uma vez por tabela):
+- `"O/CST"` se qualquer item tem `Cst` não-vazio
+- senão `"O/CSOSN"` se qualquer item tem `Csosn` não-vazio
+- senão `"O/CST"` (fallback determinístico)
+
+A coluna mista (alguns itens com CST e outros com CSOSN) é considerada inviável pelo CRT do emitente (regime tributário é por emitente, não por item) — Regime Normal usa apenas CST, Simples Nacional usa apenas CSOSN. Se aparecer no XML por inconsistência, prevalece a primeira regra (existe pelo menos um CST → `"O/CST"`).
+
+### Decision 4: Não introduzir feature flag ou config
+
+A correção é pura — restitui comportamento conforme MOC NF-e. Não há cenário onde o consumidor queira manter o bug. Logo, sem flag.
+
+## Risks / Trade-offs
+
+- **[Risk]** Consumidores externos do `DanfeSharp` que dependem do formato exato concatenado `"120"` de `ProdutoViewModel.OCst` quebrariam. → **Mitigation:** documentar a mudança no CHANGELOG/release notes (semver minor, pois é breaking de output mas a propriedade continua existindo). Avaliar se algum consumidor interno do NFe.io lê `OCst` parseando — buscar referências antes de mergear (grep em outros repos).
+- **[Risk]** Algum XML de teste do `DanfeSharp.Test` ter snapshot do PDF gerado com `"120"` no lugar errado. → **Mitigation:** rodar suite e atualizar snapshots conscientemente; documentar diff visual no PR.
+- **[Risk]** Decisão 1 (header derivado dos itens) muda comportamento em casos de NF-e onde `Emitente.CRT="3"` mas itens têm `<CSOSN>` por algum motivo (raro/malformado). → **Mitigation:** o ground-truth visual continua o do item; renderizar `"O/CSOSN"` nesse caso é mais coerente com o conteúdo das células do que mentir e mostrar `"O/CST"`.
+- **[Trade-off]** Adicionar 3 propriedades novas em `ProdutoViewModel` aumenta a superfície da classe. → Aceito porque a alternativa (raciocinar via string parsing) é pior arquitetura.
+
+## Migration Plan
+
+1. Adicionar propriedades `Origem`, `Cst`, `Csosn` ao `ProdutoViewModel` (sem remover `OCst`).
+2. Atualizar `DanfeViewModelCreator.cs:497` para popular as três propriedades; eliminar a concatenação direta de `OCst`.
+3. Transformar `OCst` em propriedade calculada a partir das três novas (com regra do separador).
+4. Atualizar `TabelaProdutosServicos.cs:25` (header) para inspecionar os itens em vez de checar `Emitente.CRT`.
+5. Adicionar testes unitários e atualizar snapshots existentes.
+6. Validar visualmente com a invoice de referência `86fed76fd38f42e1833375e33a94567c` (cliente Revenda Mais) — comparar PDF antes/depois.
+7. PR em draft → review → merge para `main` → release minor do pacote (se aplicável).
+
+**Rollback:** se houver regressão pós-merge, reverter o PR — não há migração de dados nem state persistido.
+
+## Open Questions
+
+- Algum consumidor interno do NFe.io (outros repos) lê `ProdutoViewModel.OCst` esperando o formato concatenado `"120"`? — verificar antes do merge via grep cross-repo (`OCst` em outros consumidores que linkam o DanfeSharp).
+- ~~O Manual de Orientação ao Contribuinte (MOC) NF-e especifica o caractere separador?~~ **Resolvido (2026-05-28):** o MOC 7.0 Anexo II §3.1.7 não cita literalmente o separador `/` nem o cabeçalho combinado `O/CST` — manda apenas que a coluna `CST` seja preenchida. O formato combinado é convenção de mercado (TOTVS, SAP, SmartGo, eMissor). Adotamos `/` por ser o universalmente esperado pelos receptores; se cliente Revenda Mais apontar outro padrão, reabrir.
+- A library tem outros pontos onde origem/CST/CSOSN são compostos como string? Buscar `icms.orig` e similares para garantir cobertura.

--- a/openspec/changes/archive/2026-05-28-fix-danfe-csosn-rendering/proposal.md
+++ b/openspec/changes/archive/2026-05-28-fix-danfe-csosn-rendering/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+A DANFE gerada pelo `nfe/DanfeSharp` renderiza a coluna **O/CSOSN** do bloco "DADOS DOS PRODUTOS / SERVIÇOS" de forma incorreta para o cliente Revenda Mais e potencialmente para outros emitentes: (1) origem e código tributário aparecem concatenados sem separador (`120` em vez de `1/20`); (2) o cabeçalho usa sempre `O/CSOSN` mesmo quando o emitente é do Regime Normal (deveria mostrar `O/CST`). O XML está íntegro — somente a renderização visual está errada — mas o problema gerou casos de cancelamento de NF-e por receptores que questionaram a conformidade visual com a convenção universal de mercado (TOTVS, SAP, SmartGo, eMissor, etc.). A coluna `CST` é obrigatória no DANFE conforme [MOC 7.0 — Anexo II §3.1.7](https://www.confaz.fazenda.gov.br/legislacao/arquivo-manuais/moc7-anexo-ii-manual-especificacoes-tecnicas-danfe-codigo-barras.pdf); o formato combinado `O/CST` + separador `/` não é prescrito literalmente pelo MOC, mas é convenção de mercado consolidada. A correção bloqueia retrabalho fiscal sem mudar XML nem outras colunas. Issue: [nfe/DanfeSharp#38](https://github.com/nfe/DanfeSharp/issues/38).
+
+## What Changes
+
+- Renderer da coluna ICMS (origem + CST/CSOSN) na tabela de produtos/serviços da DANFE passa a inserir **separador `/`** entre origem e código tributário (ex.: `1/20`, `0/102`).
+- Cabeçalho da coluna passa a ser **dinâmico**: `O/CST` quando o emitente é do Regime Normal (tag `<CST>` presente no grupo `<ICMS*>`) ou `O/CSOSN` quando é do Simples Nacional (tag `<CSOSN>` presente). Quando o XML mistura emitentes ou contém ambos os formatos no mesmo documento, prevalece a tag observada no item.
+- Comportamento neutro quando `<orig>` está ausente: célula exibe apenas o código (sem barra solta no início).
+- Cobertura de testes unitários cobrindo Regime Normal (CST 00/20/40), Simples Nacional (CSOSN 102/500) e ausência de `<orig>`.
+- Nenhuma mudança em XML, geração de NF-e, ou outras colunas da DANFE. Não há alteração de API pública do DanfeSharp (`Danfe.GerarPdf` continua com a mesma assinatura).
+
+## Capabilities
+
+### New Capabilities
+
+- `danfe-icms-column`: regras de renderização da coluna de tributação ICMS no bloco de produtos/serviços da DANFE de NF-e modelo 55 — incluindo formato de célula (origem/código com separador), rótulo dinâmico do cabeçalho conforme regime tributário do emitente, e fallback para XML incompleto.
+
+### Modified Capabilities
+
+_Nenhuma — repo ainda não tem specs OpenSpec (este é o primeiro change após `openspec init`)._
+
+## Impact
+
+- **Código afetado** (a confirmar no design):
+  - Renderer da tabela de produtos (provavelmente `DanfeSharp/Blocos/BlocoProdutosServicos.cs` ou equivalente)
+  - Modelo de dado de produto/imposto (provavelmente `DanfeSharp/Modelo/ProdutoViewModel.cs` ou semelhante) — para expor origem separada do código
+  - Definição do cabeçalho da tabela (label dinâmico)
+- **APIs públicas**: nenhuma quebra. A propriedade exposta hoje pode ser mantida por compatibilidade, mas o componente de renderização passa a usar uma representação mais rica (origem + código separados).
+- **Dependências externas**: nenhuma nova.
+- **Backward compatibility**: NF-e que hoje renderizam com `<orig>` ausente continuam renderizando — apenas sem a barra solta inicial.
+- **Cliente impactado positivamente**: Revenda Mais (e qualquer outro emitente cujas DANFEs sejam recebidas por contrapartes fiscalmente atentas).
+- **Não impacta**: DANFE de NFCe (modelo 65), DANFE de MDF-e, DANFE de CT-e, geração do XML.

--- a/openspec/changes/archive/2026-05-28-fix-danfe-csosn-rendering/specs/danfe-icms-column/spec.md
+++ b/openspec/changes/archive/2026-05-28-fix-danfe-csosn-rendering/specs/danfe-icms-column/spec.md
@@ -1,0 +1,108 @@
+## ADDED Requirements
+
+> **Base normativa:** o quadro "Dados dos Produtos/Serviços" do DANFE e a obrigatoriedade da coluna `CST` estão definidos no [MOC 7.0 — Anexo II — Manual de Especificações Técnicas do DANFE e Código de Barras](https://www.confaz.fazenda.gov.br/legislacao/arquivo-manuais/moc7-anexo-ii-manual-especificacoes-tecnicas-danfe-codigo-barras.pdf), §3.1.7 (página 11). O campo `<orig>` (origem da mercadoria, domínio 0–8) faz parte do grupo `<ICMS>` no schema da NF-e ([MOC 7.0 — Anexo I](https://www.confaz.fazenda.gov.br/legislacao/arquivo-manuais/moc7-anexo-i-leiaute-e-rv.pdf)). O **formato combinado `O/CST` com separador `/` é convenção de mercado** (TOTVS, SAP, SmartGo, eMissor, etc.) — não está literalmente prescrito no MOC, mas é o que receptores fiscais esperam visualmente e o que outros renderers de DANFE da indústria adotam.
+
+### Requirement: Cell rendering of `Origem/CST` or `Origem/CSOSN` in product table
+
+A coluna ICMS da tabela de produtos da DANFE de NF-e modelo 55 SHALL renderizar **origem da mercadoria** e **código de tributação** (CST ou CSOSN) separados pelo caractere `/`, lidos do grupo `<ICMS*>` do item.
+
+A regra de composição da célula é:
+
+- Se `<orig>` está presente E (`<CST>` ou `<CSOSN>`) está presente → célula = `"<orig>/<código>"`
+- Se `<orig>` está ausente E (`<CST>` ou `<CSOSN>`) está presente → célula = `"<código>"` (sem barra)
+- Se `<orig>` está presente E código está ausente → célula = `"<orig>"`
+- Se ambos ausentes → célula = `""` (vazio)
+
+`CST` e `CSOSN` são mutuamente exclusivos por item (apenas um é preenchido), conforme MOC NF-e.
+
+#### Scenario: Regime Normal — item com origem e CST
+
+- **GIVEN** um item com `<orig>1</orig><CST>20</CST>` no grupo `<ICMS20>`
+- **WHEN** a DANFE é renderizada
+- **THEN** a célula da coluna ICMS para esse item exibe `"1/20"`
+
+#### Scenario: Simples Nacional — item com origem e CSOSN
+
+- **GIVEN** um item com `<orig>0</orig><CSOSN>102</CSOSN>` no grupo `<ICMSSN102>`
+- **WHEN** a DANFE é renderizada
+- **THEN** a célula da coluna ICMS para esse item exibe `"0/102"`
+
+#### Scenario: Origem ausente — não exibir barra solta
+
+- **GIVEN** um item com `<CST>40</CST>` e sem tag `<orig>` (ou `<orig>` vazia)
+- **WHEN** a DANFE é renderizada
+- **THEN** a célula da coluna ICMS exibe `"40"` (sem `"/40"`)
+
+#### Scenario: Código ausente, apenas origem
+
+- **GIVEN** um item com `<orig>2</orig>` e sem `<CST>` nem `<CSOSN>` (XML mal-formado mas presente em base legada)
+- **WHEN** a DANFE é renderizada
+- **THEN** a célula da coluna ICMS exibe `"2"` (sem `"2/"`)
+
+#### Scenario: Ambos ausentes
+
+- **GIVEN** um item sem `<orig>`, `<CST>` nem `<CSOSN>`
+- **WHEN** a DANFE é renderizada
+- **THEN** a célula da coluna ICMS exibe string vazia
+
+### Requirement: Dynamic column header `O/CST` or `O/CSOSN` derived from items
+
+O cabeçalho da coluna ICMS na tabela de produtos SHALL ser determinado pelo conteúdo dos itens da nota, NÃO apenas pelo CRT do emitente.
+
+A regra é:
+
+- Se qualquer item da nota tem `<CST>` não-vazio → cabeçalho = `"O/CST"`
+- Senão se qualquer item da nota tem `<CSOSN>` não-vazio → cabeçalho = `"O/CSOSN"`
+- Senão (nenhum item tem código tributário estruturado) → cabeçalho = `"O/CST"` (fallback determinístico)
+
+A regra precedência (`<CST>` antes de `<CSOSN>`) trata o caso teoricamente impossível de coluna mista — se aparecer, prevalece `"O/CST"` porque Regime Normal é o caso majoritário no mercado brasileiro.
+
+#### Scenario: Todos os itens com CST — cabeçalho CST
+
+- **GIVEN** uma NF-e onde todos os itens têm `<CST>` preenchido
+- **WHEN** a DANFE é renderizada
+- **THEN** o cabeçalho da coluna ICMS exibe `"O/CST"`
+
+#### Scenario: Todos os itens com CSOSN — cabeçalho CSOSN
+
+- **GIVEN** uma NF-e onde todos os itens têm `<CSOSN>` preenchido
+- **WHEN** a DANFE é renderizada
+- **THEN** o cabeçalho da coluna ICMS exibe `"O/CSOSN"`
+
+#### Scenario: `<emit><CRT>` ausente mas itens têm CST — cabeçalho CST
+
+- **GIVEN** uma NF-e onde `<emit>` não tem o elemento `<CRT>` (ou está vazio) e todos os itens têm `<CST>` preenchido
+- **WHEN** a DANFE é renderizada
+- **THEN** o cabeçalho da coluna ICMS exibe `"O/CST"` (deriva dos itens, não do CRT)
+
+#### Scenario: Nenhum item com CST nem CSOSN — fallback
+
+- **GIVEN** uma NF-e onde nenhum item tem `<CST>` nem `<CSOSN>` (cenário improvável mas possível em XMLs antigos)
+- **WHEN** a DANFE é renderizada
+- **THEN** o cabeçalho da coluna ICMS exibe `"O/CST"`
+
+### Requirement: Backward compatibility of `ProdutoViewModel.OCst`
+
+A propriedade pública `ProdutoViewModel.OCst` SHALL continuar existindo e SHALL retornar a string formatada conforme as regras de célula descritas em "Cell rendering of `Origem/CST` or `Origem/CSOSN`" — preservando compatibilidade com consumidores externos que lêem essa propriedade.
+
+A propriedade SHALL ser calculada (computed/read-only externamente) a partir das propriedades brutas `Origem`, `Cst`, `Csosn`.
+
+A propriedade SHALL NOT retornar a forma concatenada anterior (`"120"` para origem=1+CST=20) — a correção é intencional e considerada bug fix, não breaking change.
+
+#### Scenario: OCst calculado a partir de Origem + Cst
+
+- **GIVEN** um `ProdutoViewModel` com `Origem="1"`, `Cst="20"`, `Csosn=null`
+- **WHEN** `produto.OCst` é lido
+- **THEN** retorna `"1/20"`
+
+#### Scenario: OCst calculado a partir de Origem + Csosn
+
+- **GIVEN** um `ProdutoViewModel` com `Origem="0"`, `Cst=null`, `Csosn="102"`
+- **WHEN** `produto.OCst` é lido
+- **THEN** retorna `"0/102"`
+
+#### Scenario: OCst sem origem
+
+- **GIVEN** um `ProdutoViewModel` com `Origem=null`, `Cst="40"`, `Csosn=null`
+- **WHEN** `produto.OCst` é lido
+- **THEN** retorna `"40"`

--- a/openspec/changes/archive/2026-05-28-fix-danfe-csosn-rendering/tasks.md
+++ b/openspec/changes/archive/2026-05-28-fix-danfe-csosn-rendering/tasks.md
@@ -1,0 +1,54 @@
+## 1. Investigação de uso externo (pre-flight)
+
+- [ ] 1.1 Buscar consumidores internos do NFe.io que lêem `ProdutoViewModel.OCst` para confirmar que ninguém depende do formato concatenado antigo (`"120"`). Se algum consumidor faz parsing, listar no PR e propor migração. _(Pendente — requer acesso a outros repos do NFe.io fora deste working tree.)_
+- [ ] 1.2 Confirmar com o cliente Revenda Mais (via @Carolina Fagundes) que o separador esperado é `/` e não outro caractere (`-`, espaço, etc.). _(Pendente — comunicação externa; default `/` aplicado conforme convenção universal de mercado. Não é mandato literal do MOC 7.0 Anexo II §3.1.7, que prescreve a coluna `CST` mas não o formato combinado — confirmado por leitura literal do PDF oficial em 2026-05-28.)_
+
+## 2. Modelo de dados — `ProdutoViewModel`
+
+- [x] 2.1 Adicionar propriedade pública `Origem` (`string`, nullable) em `DanfeSharp/Modelo/ProdutoViewModel.cs`, com XML doc `/// <summary>Origem da mercadoria (tag &lt;orig&gt;)</summary>`.
+- [x] 2.2 Adicionar propriedade pública `Cst` (`string`, nullable) com XML doc apontando para tag `<CST>` do grupo `<ICMS*>`.
+- [x] 2.3 Adicionar propriedade pública `Csosn` (`string`, nullable) com XML doc apontando para tag `<CSOSN>` do grupo `<ICMSSN*>`.
+- [x] 2.4 Transformar `OCst` em propriedade calculada (getter-only) que retorna a composição `Origem/codigo` conforme regra da spec `danfe-icms-column` (cell rendering). Implementado em `ProdutoViewModel.cs` com tratamento explícito de origem-only, código-only, e ambos vazios.
+
+## 3. Producer — `DanfeViewModelCreator`
+
+- [x] 3.1 Em `DanfeSharp/Modelo/DanfeViewModelCreator.cs:497`, substituída `produto.OCst = icms.orig + icms.CST + icms.CSOSN;` por três atribuições explícitas a `Origem`/`Cst`/`Csosn`.
+- [x] 3.2 Verificadas outras chamadas a `icms.orig`/`icms.CST`/`icms.CSOSN` em todo o repo — só este ponto em `DanfeViewModelCreator.cs` lia esses três campos para produto. Confirmado via `grep`.
+- [x] 3.3 Normalização aplicada: `String.IsNullOrEmpty(icms.orig) ? null : icms.orig` (idem CST e CSOSN). Cobre o caso do `XmlSerializer` retornar `""` para tags ausentes; o `OCst` computado também trata `""` como ausente por defesa em profundidade (test `OCst_OrigemEmString_TrataComoAusente`).
+
+## 4. Renderer — `TabelaProdutosServicos`
+
+- [x] 4.1 Em `DanfeSharp/Blocos/TabelaProdutosServicos.cs:25`, substituir a expressão `ViewModel.Emitente.CRT == "3" ? "O/CST" : "O/CSOSN"` por chamada ao helper estático `ProdutoViewModel.CalcularCabecalhoColunaIcms(ViewModel.Produtos)` — lógica extraída para método puro testável.
+- [x] 4.2 Verificar que a linha 75 (`p.OCst`) continua renderizando a célula corretamente — `OCst` agora é a propriedade calculada que entrega o valor formatado `"1/20"`. Confirmado: nenhuma mudança necessária neste ponto.
+- [ ] 4.3 Verificar visualmente se a coluna tem largura suficiente para `1/20` (4 chars) sem truncar — o layout antigo cabia `120` (3 chars). _(Validação manual pendente: §6 cobre.)_
+
+## 5. Testes unitários
+
+- [x] 5.1 Regime Normal: `Origem="1"`, `Cst="20"` → `OCst == "1/20"` e cabeçalho `"O/CST"`. Cobertura em `ProdutoIcmsColumnTests.OCst_RegimeNormal_OrigemComCst_RetornaOrigemBarraCst` + `Cabecalho_TodosItensComCst_RetornaOCST`.
+- [x] 5.2 Simples Nacional: `Origem="0"`, `Csosn="102"` → `OCst == "0/102"` e cabeçalho `"O/CSOSN"`. Cobertura em `OCst_SimplesNacional_OrigemComCsosn_RetornaOrigemBarraCsosn` + `Cabecalho_TodosItensComCsosn_RetornaOCSOSN`.
+- [x] 5.3 Ausência de origem: apenas `Cst="40"` → `OCst == "40"` (sem barra solta). Cobertura em `OCst_SemOrigem_ApenasCst_RetornaCodigoSemBarra` + `OCst_SemOrigem_ApenasCsosn_RetornaCodigoSemBarra`.
+- [x] 5.4 Cenário do bug reportado (CRT ausente mas itens com CST): cabeçalho derivado dos itens é `"O/CST"`. Cobertura em `Cabecalho_RegressaoBug38_RevendaMaisComCstESemEmitenteCRT`.
+- [x] 5.5 Fallback total (nada estruturado no XML): célula vazia, cabeçalho `"O/CST"`. Cobertura em `OCst_TodosNull_RetornaStringVazia` + `Cabecalho_NenhumItemComCodigo_RetornaOCSTFallback` + `Cabecalho_ProdutosNull_RetornaOCSTFallback` + `Cabecalho_ListaVazia_RetornaOCSTFallback`.
+- [x] 5.6 `dotnet vstest DanfeSharp.Test.dll --TestCaseFilter:"FullyQualifiedName~ProdutoIcmsColumnTests"` → **15/15 aprovados, 0 falhas, 297 ms**. As 21 falhas restantes na suite completa (LogoTests, demais DanfeTest) são pré-existentes em `DanfeViewModel.TextoReservadoFisco():355` lançando `NotImplementedException` — fora do escopo de #38.
+
+## 6. Validação visual (manual)
+
+- [ ] 6.1 Gerar PDF da DANFE para a invoice de referência `86fed76fd38f42e1833375e33a94567c` (company `c7c78c0f701964d36adcb0d2263e3d1b4` do cliente Revenda Mais). Confirmar visualmente que a célula da coluna ICMS exibe `1/20` e o cabeçalho exibe `O/CST` (ou `O/CSOSN` conforme regime real).
+- [ ] 6.2 Gerar DANFE de um XML genérico do diretório `DanfeSharp.Test/Xml/NFe/` em regime normal e em Simples para confirmar visualmente que ambos os casos renderizam corretamente, com zero regressão estética nas demais colunas.
+- [ ] 6.3 Tirar prints antes/depois e anexar no PR como evidência.
+
+## 7. Documentação e changelog
+
+- [x] 7.1 Repo não mantém CHANGELOG.md — alterações são documentadas em commit message + body da PR. Esta task fica satisfeita pelo body de PR #41.
+- [x] 7.2 XML doc do `OCst` atualizado em `ProdutoViewModel.cs` explicando o formato `"<origem>/<código>"` e a regra de omissão de componentes vazios.
+
+## 8. PR e revisão
+
+- [ ] 8.1 Garantir que o body do PR linka a issue `Fixes #38` para fechamento automático no merge.
+- [ ] 8.2 Solicitar review do @joaokita (co-assignee automático no repo) e de algum reviewer fiscal-aware do time NFe.io.
+- [ ] 8.3 Após approval, retirar o draft e mergear (squash) em `main`.
+
+## 9. Arquivamento OpenSpec
+
+- [ ] 9.1 Após merge, rodar `openspec validate` para confirmar consistência.
+- [ ] 9.2 Rodar `openspec archive fix-danfe-csosn-rendering` para mover a change para `openspec/changes/archive/` e atualizar `openspec/specs/danfe-icms-column/spec.md` com os requirements ADDED desta change.

--- a/openspec/specs/danfe-cancelled-watermark/spec.md
+++ b/openspec/specs/danfe-cancelled-watermark/spec.md
@@ -1,0 +1,91 @@
+# danfe-cancelled-watermark Specification
+
+## Purpose
+
+Define como o `nfe/DanfeSharp` indica visualmente que a DANFE corresponde a uma NF-e cancelada: detecção via flag explícita `DanfeViewModel.IsCancelled` (mecanismo primário — reflete a realidade do cancelamento via evento `NFeProcEvento` `tpEvento=110111` em NF-e modelo 55, que não altera o `<cStat>` do XML protocolo da nota original) + fallback OR via `CodigoStatusReposta == 101` (compat com cenário raro de XML modificado), e renderização da marca d'água "DOCUMENTO CANCELADO" centralizada em **todas as páginas** da DANFE — retrato e paisagem, multi-página inclusa.
+
+**Base normativa:** [MOC 7.0 — Anexo II §3.10.1 (Marca d'Água)](https://www.confaz.fazenda.gov.br/legislacao/arquivo-manuais/moc7-anexo-ii-manual-especificacoes-tecnicas-danfe-codigo-barras.pdf) autoriza literalmente: *"O formulário poderá conter marca d'água desde que não prejudique a legibilidade dos dados impressos."* NÃO obriga marca para nota cancelada nem especifica texto/posição/opacidade. Texto e estilo (fonte 48pt regular, cinza RGB 0.35, centralizado) são **convenção universal de mercado** (TOTVS, SAP, SmartGo, eMissor) alinhada ao padrão de "SEM VALOR FISCAL — AMBIENTE DE HOMOLOGAÇÃO" já implementado no DanfeSharp.
+
+## Requirements
+### Requirement: Detect cancelled invoice via `IsCancelled` flag
+
+O `DanfeSharp.Modelo.DanfeViewModel` SHALL expor propriedade pública `IsCancelled` (`bool`, default `false`). Quando setada como `true`, a DANFE renderiza marca d'água "DOCUMENTO CANCELADO" em todas as páginas. Quando `false` (default), nenhuma marca de cancelamento é desenhada.
+
+#### Scenario: Default false — DANFE renderiza sem marca
+
+- **GIVEN** um `DanfeViewModel` recém-criado (sem setar `IsCancelled`)
+- **WHEN** a DANFE é gerada
+- **THEN** a propriedade `IsCancelled == false` E o PDF gerado não contém marca "DOCUMENTO CANCELADO"
+
+#### Scenario: Consumer seta IsCancelled = true
+
+- **GIVEN** um `DanfeViewModel` carregado de XML de NF-e ativa (`infProt.cStat == 100`)
+- **WHEN** o consumer seta `model.IsCancelled = true` antes de gerar a DANFE
+- **THEN** o PDF gerado contém marca "DOCUMENTO CANCELADO" centralizada em todas as páginas
+
+### Requirement: Detect cancelled invoice via legacy `cStat=101` fallback
+
+Como mecanismo OR adicional (fallback de compatibilidade), a DANFE SHALL renderizar a marca de cancelamento quando `CodigoStatusReposta == 101`, mesmo se `IsCancelled == false`. Cobre o cenário (atípico mas existente) onde o XML protocolo carregado já reflete o status de cancelamento via `cStat=101`.
+
+#### Scenario: XML com infProt.cStat=101
+
+- **GIVEN** um XML de NF-e cujo `<protNFe><infProt><cStat>101</cStat>` está presente e o `DanfeViewModel.CodigoStatusReposta == 101`
+- **WHEN** a DANFE é gerada (sem flag explícita)
+- **THEN** o PDF gerado contém marca "DOCUMENTO CANCELADO" em todas as páginas
+
+#### Scenario: Ambos os mecanismos ativados — marca aparece uma única vez
+
+- **GIVEN** `IsCancelled == true` E `CodigoStatusReposta == 101`
+- **WHEN** a DANFE é gerada
+- **THEN** o PDF contém uma única instância da marca "DOCUMENTO CANCELADO" por página (não duplicada)
+
+### Requirement: Render "DOCUMENTO CANCELADO" watermark on every page
+
+A marca d'água SHALL ser desenhada em **todas** as páginas geradas da DANFE (não só a primeira), garantindo que receptores fiscais identifiquem o status mesmo se receberem apenas folhas individuais de uma DANFE multi-página.
+
+O estilo visual SHALL seguir o padrão do `DesenharAvisoHomologacao` existente: `TextStack` centralizado horizontal e verticalmente no `RetanguloCorpo` (área de produtos da página), fonte `Estilo.CriarFonteRegular(48)`, cor `DeviceRGBColor(0.35, 0.35, 0.35)` cinza médio, `LineHeightScale=0.9F`.
+
+#### Scenario: Single-page DANFE — marca na página única
+
+- **GIVEN** uma DANFE de NF-e cancelada que cabe em 1 página
+- **WHEN** a DANFE é gerada
+- **THEN** a página única do PDF contém a marca
+
+#### Scenario: Multi-page DANFE — marca em todas as páginas
+
+- **GIVEN** uma DANFE de NF-e cancelada com 20 itens (gera ≥ 2 páginas)
+- **WHEN** a DANFE é gerada
+- **THEN** cada página do PDF gerado contém a marca "DOCUMENTO CANCELADO" centralizada
+
+#### Scenario: Visual style spec
+
+- **GIVEN** uma DANFE de NF-e cancelada
+- **WHEN** o PDF é gerado e a marca é extraída visualmente
+- **THEN** o texto "DOCUMENTO CANCELADO" aparece com fonte regular grande (~48pt), cor cinza médio (RGB 0.35,0.35,0.35), centralizado na área principal da página, sem obscurecer dados estruturados (números, descrição de itens) — a cor cinza é leve o suficiente para o conteúdo continuar legível por trás
+
+### Requirement: Co-existence with homologação watermark
+
+Quando uma NF-e está **em homologação E cancelada** simultaneamente (cenário raro, válido em testes), AMBOS os avisos SHALL aparecer na mesma página — "SEM VALOR FISCAL / AMBIENTE DE HOMOLOGAÇÃO" (homologação) **e** "DOCUMENTO CANCELADO" (cancelada). A sobreposição é aceitável porque sinaliza claramente os dois estados, ambos relevantes para o receptor.
+
+#### Scenario: NF-e em homologação cancelada — dois avisos sobrepostos
+
+- **GIVEN** uma NF-e cuja `TipoAmbiente != 1` (homologação) E `IsCancelled == true`
+- **WHEN** a DANFE é gerada
+- **THEN** o PDF contém AMBOS os avisos: "SEM VALOR FISCAL / AMBIENTE DE HOMOLOGAÇÃO" e "DOCUMENTO CANCELADO", centralizados no mesmo retângulo (visualmente sobrepostos)
+
+### Requirement: Zero regression for non-cancelled DANFE
+
+DANFE de NF-e **não cancelada** (`IsCancelled == false` E `CodigoStatusReposta != 101`) SHALL renderizar **idêntica** ao estado anterior a esta change — sem qualquer marca de cancelamento, sem alteração de layout ou tamanho do PDF resultante além de variação atribuível a metadados (alguns bytes).
+
+#### Scenario: DANFE não-cancelada renderiza sem marca
+
+- **GIVEN** uma NF-e ativa (`IsCancelled == false`, `CodigoStatusReposta == 100`)
+- **WHEN** a DANFE é gerada
+- **THEN** o PDF não contém texto "DOCUMENTO CANCELADO" em nenhuma página
+
+#### Scenario: Backward compat — código existente não setou IsCancelled
+
+- **GIVEN** código consumidor que não conhece a nova propriedade `IsCancelled` (escrito antes desta change)
+- **WHEN** chama `DanfeViewModelCreator.CriarDeArquivoXml(path)` e gera a DANFE
+- **THEN** o PDF gerado é idêntico ao gerado antes desta change (zero regressão)
+

--- a/openspec/specs/danfe-icms-column/spec.md
+++ b/openspec/specs/danfe-icms-column/spec.md
@@ -1,0 +1,114 @@
+# danfe-icms-column Specification
+
+## Purpose
+
+Define como o `nfe/DanfeSharp` renderiza a coluna de tributação ICMS (`O/CST` ou `O/CSOSN`) no bloco "Dados dos Produtos / Serviços" da DANFE de NF-e modelo 55: formato da célula combinando origem (`<orig>`) + código tributário (`<CST>` ou `<CSOSN>`), rótulo dinâmico do cabeçalho conforme o conteúdo dos itens, e fallback determinístico para XML incompleto.
+
+**Base normativa:** o quadro "Dados dos Produtos/Serviços" e a obrigatoriedade da coluna `CST` estão definidos no [MOC 7.0 — Anexo II §3.1.7](https://www.confaz.fazenda.gov.br/legislacao/arquivo-manuais/moc7-anexo-ii-manual-especificacoes-tecnicas-danfe-codigo-barras.pdf). A tag `<orig>` faz parte do schema XML em [MOC 7.0 — Anexo I](https://www.confaz.fazenda.gov.br/legislacao/arquivo-manuais/moc7-anexo-i-leiaute-e-rv.pdf). O formato combinado `O/CST` com separador `/` é convenção universal de mercado (não mandato literal do MOC), adotado por TOTVS, SAP, SmartGo, eMissor e demais renderers da indústria.
+
+## Requirements
+### Requirement: Cell rendering of `Origem/CST` or `Origem/CSOSN` in product table
+
+A coluna ICMS da tabela de produtos da DANFE de NF-e modelo 55 SHALL renderizar **origem da mercadoria** e **código de tributação** (CST ou CSOSN) separados pelo caractere `/`, lidos do grupo `<ICMS*>` do item.
+
+A regra de composição da célula é:
+
+- Se `<orig>` está presente E (`<CST>` ou `<CSOSN>`) está presente → célula = `"<orig>/<código>"`
+- Se `<orig>` está ausente E (`<CST>` ou `<CSOSN>`) está presente → célula = `"<código>"` (sem barra)
+- Se `<orig>` está presente E código está ausente → célula = `"<orig>"`
+- Se ambos ausentes → célula = `""` (vazio)
+
+`CST` e `CSOSN` são mutuamente exclusivos por item (apenas um é preenchido), conforme MOC NF-e.
+
+#### Scenario: Regime Normal — item com origem e CST
+
+- **GIVEN** um item com `<orig>1</orig><CST>20</CST>` no grupo `<ICMS20>`
+- **WHEN** a DANFE é renderizada
+- **THEN** a célula da coluna ICMS para esse item exibe `"1/20"`
+
+#### Scenario: Simples Nacional — item com origem e CSOSN
+
+- **GIVEN** um item com `<orig>0</orig><CSOSN>102</CSOSN>` no grupo `<ICMSSN102>`
+- **WHEN** a DANFE é renderizada
+- **THEN** a célula da coluna ICMS para esse item exibe `"0/102"`
+
+#### Scenario: Origem ausente — não exibir barra solta
+
+- **GIVEN** um item com `<CST>40</CST>` e sem tag `<orig>` (ou `<orig>` vazia)
+- **WHEN** a DANFE é renderizada
+- **THEN** a célula da coluna ICMS exibe `"40"` (sem `"/40"`)
+
+#### Scenario: Código ausente, apenas origem
+
+- **GIVEN** um item com `<orig>2</orig>` e sem `<CST>` nem `<CSOSN>` (XML mal-formado mas presente em base legada)
+- **WHEN** a DANFE é renderizada
+- **THEN** a célula da coluna ICMS exibe `"2"` (sem `"2/"`)
+
+#### Scenario: Ambos ausentes
+
+- **GIVEN** um item sem `<orig>`, `<CST>` nem `<CSOSN>`
+- **WHEN** a DANFE é renderizada
+- **THEN** a célula da coluna ICMS exibe string vazia
+
+### Requirement: Dynamic column header `O/CST` or `O/CSOSN` derived from items
+
+O cabeçalho da coluna ICMS na tabela de produtos SHALL ser determinado pelo conteúdo dos itens da nota, NÃO apenas pelo CRT do emitente.
+
+A regra é:
+
+- Se qualquer item da nota tem `<CST>` não-vazio → cabeçalho = `"O/CST"`
+- Senão se qualquer item da nota tem `<CSOSN>` não-vazio → cabeçalho = `"O/CSOSN"`
+- Senão (nenhum item tem código tributário estruturado) → cabeçalho = `"O/CST"` (fallback determinístico)
+
+A regra precedência (`<CST>` antes de `<CSOSN>`) trata o caso teoricamente impossível de coluna mista — se aparecer, prevalece `"O/CST"` porque Regime Normal é o caso majoritário no mercado brasileiro.
+
+#### Scenario: Todos os itens com CST — cabeçalho CST
+
+- **GIVEN** uma NF-e onde todos os itens têm `<CST>` preenchido
+- **WHEN** a DANFE é renderizada
+- **THEN** o cabeçalho da coluna ICMS exibe `"O/CST"`
+
+#### Scenario: Todos os itens com CSOSN — cabeçalho CSOSN
+
+- **GIVEN** uma NF-e onde todos os itens têm `<CSOSN>` preenchido
+- **WHEN** a DANFE é renderizada
+- **THEN** o cabeçalho da coluna ICMS exibe `"O/CSOSN"`
+
+#### Scenario: `<emit><CRT>` ausente mas itens têm CST — cabeçalho CST
+
+- **GIVEN** uma NF-e onde `<emit>` não tem o elemento `<CRT>` (ou está vazio) e todos os itens têm `<CST>` preenchido
+- **WHEN** a DANFE é renderizada
+- **THEN** o cabeçalho da coluna ICMS exibe `"O/CST"` (deriva dos itens, não do CRT)
+
+#### Scenario: Nenhum item com CST nem CSOSN — fallback
+
+- **GIVEN** uma NF-e onde nenhum item tem `<CST>` nem `<CSOSN>` (cenário improvável mas possível em XMLs antigos)
+- **WHEN** a DANFE é renderizada
+- **THEN** o cabeçalho da coluna ICMS exibe `"O/CST"`
+
+### Requirement: Backward compatibility of `ProdutoViewModel.OCst`
+
+A propriedade pública `ProdutoViewModel.OCst` SHALL continuar existindo e SHALL retornar a string formatada conforme as regras de célula descritas em "Cell rendering of `Origem/CST` or `Origem/CSOSN`" — preservando compatibilidade com consumidores externos que lêem essa propriedade.
+
+A propriedade SHALL ser calculada (computed/read-only externamente) a partir das propriedades brutas `Origem`, `Cst`, `Csosn`.
+
+A propriedade SHALL NOT retornar a forma concatenada anterior (`"120"` para origem=1+CST=20) — a correção é intencional e considerada bug fix, não breaking change.
+
+#### Scenario: OCst calculado a partir de Origem + Cst
+
+- **GIVEN** um `ProdutoViewModel` com `Origem="1"`, `Cst="20"`, `Csosn=null`
+- **WHEN** `produto.OCst` é lido
+- **THEN** retorna `"1/20"`
+
+#### Scenario: OCst calculado a partir de Origem + Csosn
+
+- **GIVEN** um `ProdutoViewModel` com `Origem="0"`, `Cst=null`, `Csosn="102"`
+- **WHEN** `produto.OCst` é lido
+- **THEN** retorna `"0/102"`
+
+#### Scenario: OCst sem origem
+
+- **GIVEN** um `ProdutoViewModel` com `Origem=null`, `Cst="40"`, `Csosn=null`
+- **WHEN** `produto.OCst` é lido
+- **THEN** retorna `"40"`
+

--- a/openspec/specs/danfe-payment-block/spec.md
+++ b/openspec/specs/danfe-payment-block/spec.md
@@ -1,0 +1,145 @@
+# danfe-payment-block Specification
+
+## Purpose
+
+Define como o `nfe/DanfeSharp` renderiza o bloco "Forma de Pagamento" no DANFE de NF-e modelo 55: schema do grupo `<pag>/<detPag>/<xPag>` no XML, mapeamento `tPag → descrição` legível via `[DescriptionAttribute]` do enum `FormaPagamento`, prevalência de `xPag` sobre a descrição genérica do enum, omissão graciosa quando o XML não contém `<pag>`, e padrão visual em cards (espelhando `Duplicata`/FATURA-DUPLICATA) com colunas `Forma de Pagamento` + `Valor:`.
+
+**Base normativa:** a [NT 2016.002 v1.50](https://www.nfe.fazenda.gov.br/portal/exibirArquivo.aspx?conteudo=tQNDQOeNeyI%3D) tornou o grupo `<pag>` obrigatório no XML da NF-e (produção desde 2018). O [MOC 7.0 — Anexo II](https://www.confaz.fazenda.gov.br/legislacao/arquivo-manuais/moc7-anexo-ii-manual-especificacoes-tecnicas-danfe-codigo-barras.pdf) NÃO tem seção dedicada à forma de pagamento para DANFE NF-e modelo 55 (verificado literalmente em 2026-05-28). O bloco visual no DANFE é **convenção universal de mercado** (TOTVS, SAP, SmartGo, eMissor) — receptores fiscais habituaram-se a essa apresentação.
+
+## Requirements
+### Requirement: Schema parsing of `<pag>/<detPag>/xPag` group
+
+O renderer SHALL deserializar o grupo `<pag><detPag>` do XML da NF-e incluindo a tag `<xPag>` (descrição livre da forma de pagamento). A propriedade `detPag.xPag` deve ser opcional — XMLs anteriores à NT 2016.002 ou que não tenham `<xPag>` continuam parseando sem erro.
+
+#### Scenario: XML com `<xPag>` preenchido
+
+- **GIVEN** um XML com `<pag><detPag><tPag>99</tPag><xPag>RECURSOS PROPRIOS</xPag><vPag>48000.00</vPag></detPag></pag>`
+- **WHEN** o XML é deserializado pelo `ProcNFeSerializer`
+- **THEN** `detPag.xPag == "RECURSOS PROPRIOS"`, `detPag.tPag == FormaPagamento.fpOutros`, `detPag.vPag == 48000.00m`
+
+#### Scenario: XML sem `<xPag>`
+
+- **GIVEN** um XML com `<pag><detPag><tPag>01</tPag><vPag>100.00</vPag></detPag></pag>` (sem `<xPag>`)
+- **WHEN** o XML é deserializado
+- **THEN** `detPag.xPag == null` (ou string vazia), `detPag.tPag == FormaPagamento.fpDinheiro`, `detPag.vPag == 100.00m`
+
+#### Scenario: XML sem grupo `<pag>` (NF-e antiga ou v4.0+ com `tPag=90`)
+
+- **GIVEN** um XML de NF-e que não contém o elemento `<pag>` (ex.: fixture `v3.10_Retrato.xml`)
+- **WHEN** o XML é deserializado
+- **THEN** `infNFe.pag == null` (ou lista vazia) — sem exceção lançada
+
+### Requirement: ViewModel exposes `Descricao` mapped from `xPag`
+
+O `DanfeSharp.Modelo.DetalheViewModel` SHALL expor uma propriedade pública `Descricao` (`string`, opcional) que reflete o conteúdo da tag XML `<xPag>`. O `DanfeViewModelCreator` SHALL populá-la quando o XML for processado.
+
+#### Scenario: Producer popula Descricao
+
+- **GIVEN** um XML com `<detPag><tPag>99</tPag><xPag>BOLETO BB</xPag><vPag>500.00</vPag></detPag>`
+- **WHEN** `DanfeViewModelCreator.CriarDeStringXml(xml)` é chamado
+- **THEN** o `DanfeViewModel.Pagamento[0].DetalhePagamento[0].Descricao == "BOLETO BB"`
+
+#### Scenario: Producer normaliza string vazia para null
+
+- **GIVEN** um XML com `<xPag></xPag>` (elemento presente mas vazio)
+- **WHEN** o XML é processado
+- **THEN** `DetalheViewModel.Descricao == null` (não string vazia) — para consistência com a regra de "ausência" em outros campos do projeto
+
+### Requirement: Render block "FORMA DE PAGAMENTO" when `Pagamento` is populated
+
+A DANFE de NF-e modelo 55 SHALL renderizar um bloco com cabeçalho "Forma de Pagamento" quando `ViewModel.Pagamento` contém pelo menos um `DetalheViewModel`. O bloco SHALL aparecer entre o "Cálculo do Imposto" e o "Transportador" no fluxo visual da DANFE. Cada `DetalheViewModel` SHALL ocupar uma linha com duas células: **FORMA PAGAMENTO** (descrição) e **VALOR** (numérico em moeda brasileira).
+
+#### Scenario: NF-e com 1 detPag
+
+- **GIVEN** uma NF-e com `Pagamento = [ { DetalhePagamento = [ DetalheViewModel { FormaPagamento=fpOutros, Descricao="RECURSOS PROPRIOS", Valor=48000.00m } ] } ]`
+- **WHEN** a DANFE é renderizada
+- **THEN** aparece um bloco com cabeçalho "Forma de Pagamento" contendo 1 linha: "RECURSOS PROPRIOS" + "R$ 48.000,00"
+
+#### Scenario: NF-e com múltiplos detPag
+
+- **GIVEN** uma NF-e com 3 itens em `DetalhePagamento`: (Dinheiro, R$ 100), (Cartão de Crédito, R$ 50), (PIX [tPag=17], R$ 25)
+- **WHEN** a DANFE é renderizada
+- **THEN** o bloco "Forma de Pagamento" exibe 3 linhas, uma para cada `DetalheViewModel`, na ordem do XML
+
+### Requirement: Cell formatting for FORMA PAGAMENTO column
+
+A célula da coluna "FORMA PAGAMENTO" SHALL conter o conteúdo de `DetalheViewModel.Descricao` quando preenchido; caso contrário, a descrição derivada do `[DescriptionAttribute]` do enum `FormaPagamento` (ex.: `fpDinheiro → "Dinheiro"`, `fpCartaoCredito → "Cartão de Crédito"`, `fpOutros → "Outros"`).
+
+#### Scenario: Descricao prevalece sobre descrição do enum
+
+- **GIVEN** `DetalheViewModel { FormaPagamento=fpCartaoCredito, Descricao="VISA 4× 2,5%" }`
+- **WHEN** a célula FORMA PAGAMENTO é renderizada
+- **THEN** o conteúdo da célula é "VISA 4× 2,5%" (não "Cartão de Crédito")
+
+#### Scenario: Sem Descricao, usa enum
+
+- **GIVEN** `DetalheViewModel { FormaPagamento=fpDinheiro, Descricao=null }`
+- **WHEN** a célula FORMA PAGAMENTO é renderizada
+- **THEN** o conteúdo é "Dinheiro" (derivado do `[Description]` do enum)
+
+#### Scenario: tPag=99 sempre exige Descricao para ser informativo
+
+- **GIVEN** `DetalheViewModel { FormaPagamento=fpOutros, Descricao="RECURSOS PROPRIOS" }`
+- **WHEN** a célula FORMA PAGAMENTO é renderizada
+- **THEN** o conteúdo é "RECURSOS PROPRIOS"
+
+#### Scenario: tPag=99 sem Descricao usa fallback genérico
+
+- **GIVEN** `DetalheViewModel { FormaPagamento=fpOutros, Descricao=null }` (XML mal-formado mas possível)
+- **WHEN** a célula FORMA PAGAMENTO é renderizada
+- **THEN** o conteúdo é "Outros" (descrição do enum) — sem null reference
+
+### Requirement: Cell formatting for VALOR column
+
+A célula da coluna "VALOR" SHALL renderizar `DetalheViewModel.Valor` em formato numérico brasileiro: separador de milhar `.`, separador decimal `,`, duas casas decimais sempre. **Sem prefixo `R$`** — segue a convenção do `DanfeSharp` para campos numéricos dentro de blocos (`BlocoCalculoImposto`, `BlocoCalculoIssqn` também usam apenas o número formatado, sem `R$`). O prefixo `R$` na DANFE aparece apenas em totalizadores específicos (cabeçalho/canhoto), não em blocos de campos.
+
+#### Scenario: Valor inteiro
+
+- **GIVEN** `Valor = 48000.00m`
+- **WHEN** a célula VALOR é renderizada
+- **THEN** o conteúdo é `48.000,00`
+
+#### Scenario: Valor com decimais
+
+- **GIVEN** `Valor = 123.45m`
+- **WHEN** a célula VALOR é renderizada
+- **THEN** o conteúdo é `123,45`
+
+#### Scenario: Valor grande
+
+- **GIVEN** `Valor = 1234567.89m`
+- **WHEN** a célula VALOR é renderizada
+- **THEN** o conteúdo é `1.234.567,89`
+
+### Requirement: Graceful omission when `<pag>` is absent
+
+A DANFE SHALL NOT renderizar o bloco "Forma de Pagamento" quando o XML não contém o grupo `<pag>` ou quando o grupo está presente mas sem nenhum `<detPag>`. A ausência do bloco NÃO SHALL afetar o layout dos demais blocos (Transportador continua aparecendo na posição atual; cálculo de imposto também).
+
+#### Scenario: NF-e antiga sem `<pag>`
+
+- **GIVEN** uma NF-e cujo XML é v3.10 sem grupo `<pag>` (ex.: fixture `v3.10_Retrato.xml`)
+- **WHEN** a DANFE é renderizada
+- **THEN** o PDF gerado é idêntico ao gerado antes desta change (zero regressão visual)
+
+#### Scenario: NF-e com `<pag>` vazio
+
+- **GIVEN** uma NF-e com `<pag></pag>` (presente mas vazio — não conforme, mas possível por bug do emissor)
+- **WHEN** a DANFE é renderizada
+- **THEN** o bloco "Forma de Pagamento" é omitido (não desenha cabeçalho nem tabela)
+
+### Requirement: Helper `FormaPagamento.GetDescricao()` reusable across the project
+
+O renderer SHALL expor um helper público (extension method ou static helper) que retorna a descrição legível de um valor `FormaPagamento` lendo o `DescriptionAttribute` do enum por reflexão. Esse helper SHALL retornar uma string não-vazia para todos os valores definidos no enum (`01` a `19`, `90`, `99`).
+
+#### Scenario: Descrição de cada valor do enum
+
+- **GIVEN** o enum `FormaPagamento` com `[Description("Dinheiro")]` em `fpDinheiro`
+- **WHEN** `FormaPagamentoExtensions.GetDescricao(FormaPagamento.fpDinheiro)` é chamado
+- **THEN** retorna `"Dinheiro"`
+
+#### Scenario: Helper não lança em valor desconhecido
+
+- **GIVEN** um valor inteiro `(FormaPagamento)42` (fora do enum, caso de XML com novo código antes do enum ser atualizado)
+- **WHEN** o helper é chamado
+- **THEN** retorna `""` (string vazia) ou o código numérico como string — sem exceção
+


### PR DESCRIPTION
ajustes Revenda Mais (CST/CSOSN + Forma de Pagamento + Marca Cancelada) (#43)

* chore(openspec): bootstrap + change fix-danfe-csosn-rendering (#38)

Initialize OpenSpec (--tools=claude) and propose change covering the ICMS column rendering bug reported in nfe/DanfeSharp#38:

- Concatenation without separator (e.g. "120" instead of "1/20") in DanfeViewModelCreator.cs:497
- Static header label "O/CSOSN" derived from Emitente.CRT only, fragile when CRT is missing in the XML

Artifacts in openspec/changes/fix-danfe-csosn-rendering/:
- proposal.md: motivation, capabilities, impact
- design.md: 4 decisions anchored on real code (item-derived header, separate Origem/Cst/Csosn properties, OCst as computed, no feature flag)
- specs/danfe-icms-column/spec.md: 3 requirements + scenarios
- tasks.md: 9 task groups (investigation, model, producer, renderer, tests, visual validation, docs, PR, archive)

No code changes yet — implementation lands via /opsx:apply on a follow-up commit.



* fix(danfe): coluna ICMS — separador / e cabeçalho derivado dos itens (#38)

Corrige dois sintomas reportados pelo cliente Revenda Mais na coluna "O/CSOSN" do bloco produtos da DANFE:

1. Origem e código (CST/CSOSN) concatenados sem separador ("120" em vez de "1/20"). Causa: `produto.OCst = icms.orig + icms.CST + icms.CSOSN` em `DanfeViewModelCreator.cs:497`.

2. Cabeçalho "O/CSOSN" mesmo para emitentes do Regime Normal quando `<emit><CRT>` está ausente/inconsistente no XML. Causa: lógica dependia só de `Emitente.CRT == "3"`.

Mudanças

- `ProdutoViewModel` ganha `Origem`/`Cst`/`Csosn` separados. `OCst` vira propriedade calculada que aplica "<origem>/<código>" e omite componentes vazios (XMLs sem <orig> exibem só o código).
- `ProdutoViewModel.CalcularCabecalhoColunaIcms(produtos)` — helper estático que decide o cabeçalho inspecionando os itens da nota (se algum tem CST → "O/CST"; senão CSOSN → "O/CSOSN"; fallback "O/CST"). Mais robusto que confiar em `Emitente.CRT`.
- `DanfeViewModelCreator` popula `Origem`/`Cst`/`Csosn` normalizando strings vazias do XmlSerializer para null.
- `TabelaProdutosServicos` consome o helper.

Testes

`DanfeSharp.Test/ProdutoIcmsColumnTests.cs`: 15 testes (8 de célula, 7 de cabeçalho), incluindo regressão do caso Revenda Mais (CRT ausente + CST nos itens → "O/CST"). 15/15 verdes via `dotnet vstest`.

Hotfix tangencial (pre-existente em `origin/main`, bloqueava build do projeto de teste)

- `FabricaFake.cs:51`: cast `(decimal?)v` para `vFCPUFDest`.
- `DanfeTest.cs:63`: `DanfeCCC` renomeado para `DanfeCartaCorrecao` (rename antigo não propagado).

Pendente (manual)

- §1 pre-flight: confirmar com Carolina que separador é `/` e grep cross-repo por `ProdutoViewModel.OCst`.
- §6 validação visual: gerar DANFE da invoice de referência do Revenda Mais e comparar PDF antes/depois.

OpenSpec change: openspec/changes/fix-danfe-csosn-rendering/
Spec validated: `openspec validate` OK.

Fixes #38



* docs(openspec): calibrar base normativa do change #38 (MOC 7.0 §3.1.7)

Após leitura literal do MOC 7.0 Anexo II (PDF oficial do CONFAZ), constatei que:

- §3.1.7 (página 11) lista a coluna "CST" como obrigatória no quadro "Dados dos Produtos/Serviços", mas NÃO prescreve literalmente o formato combinado "O/CST" nem o separador "/".
- O campo <orig> faz parte do schema do XML (Anexo I) mas o Anexo II não menciona apresentação visual conjunta com CST/CSOSN.
- O formato "O/CST" com separador "/" é convenção universal de mercado (TOTVS, SAP, SmartGo, eMissor, etc.) — não mandato literal.

Calibragem aplicada em:
- proposal.md (Why): substituída "conformidade visual com MOC v7.0+" por "convenção universal de mercado", com referência §3.1.7 para a parte que é mandato (coluna CST).
- design.md (Decision 3): nova seção "Base normativa" com URLs do CONFAZ para Anexo I + Anexo II. Open Question sobre separador marcada como resolvida.
- specs/danfe-icms-column/spec.md: nota normativa no topo do bloco ADDED Requirements explicando o que é mandato literal vs convenção.
- tasks.md §1.2: contexto expandido — separador "/" é convenção universal, não MOC literal.

Sem mudança de código nem de comportamento; só de citação/justificativa. Implementation alinhada com convenção do mercado, que é o que receptores fiscais esperam ver (raiz do problema com cliente Revenda Mais).

Fixes #38 (continued)



* chore(openspec): archive fix-danfe-csosn-rendering → specs/danfe-icms-column

- Move openspec/changes/fix-danfe-csosn-rendering/ → openspec/changes/archive/2026-05-28-fix-danfe-csosn-rendering/
- Promote ADDED requirements to openspec/specs/danfe-icms-column/spec.md
- Preencher Purpose com base normativa (MOC 7.0 §3.1.7) — substituindo o boilerplate "TBD" gerado pelo CLI

A spec danfe-icms-column passa a ser fonte de verdade para qualquer mudança futura na coluna ICMS da DANFE. Mudanças subsequentes devem ser propostas como MODIFIED/ADDED via /opsx:new ou /opsx:propose.

Note: 11 tasks ficaram incompletas no archive (manuais/externas — §1.1 grep cross-repo, §1.2 confirmar com Carolina, §4.3 validar largura visual, §6 validação visual com XML real do Revenda Mais, §8 review + merge, §9 archive já feita aqui). O archive forçou via --yes flag por se tratar de tarefas extra-código.

Fixes #38 (continued)



* chore(openspec): plan add-danfe-payment-block (#39)

Initialize OpenSpec na branch (igual a #38) e propor o change cobrindo a implementação do bloco "Forma de Pagamento" no DANFE de NF-e modelo 55:

PROBLEMA RAIZ
- DanfeSharp não renderiza bloco visual de pagamento mesmo quando o XML traz <pag><detPag> preenchido (NT 2016.002 v1.50 tornou obrigatório desde 2018).
- Cliente Revenda Mais reportou via Carolina Fagundes / Teams 2026-05-27; invoice 9175b02ac0cf4ed898025c4bad09e2fe.

ESTADO DO CÓDIGO (auditado)
- Schema XML: pag/detPag/FormaPagamento enum já existem (ProcNFe.cs) com Description em cada tPag (01..19, 90, 99); FALTA xPag em detPag.
- ViewModel: PagamentoViewModel + DetalheViewModel + CartaoViewModel já existem; FALTA Descricao em DetalheViewModel.
- Producer (DanfeViewModelCreator) já popula model.Pagamento; falta apenas mapear xPag → Descricao.
- FALTA renderer visual (BlocoFormaPagamento.cs).
- FALTA inserção no fluxo do construtor de Danfe.cs.

BASE NORMATIVA CALIBRADA (lição aprendida do #38)
- MOC 7.0 Anexo II não tem seção dedicada a forma de pagamento para DANFE NF-e modelo 55 (verifiquei literalmente o PDF do CONFAZ; zero ocorrências de "pagamento"/"detPag"/"tPag" no texto).
- NT 2016.002 obrigou o grupo <pag> no XML; o manual do DANFE NFCe (Anexo III) mandou exibir o bloco no cupom da NFCe.
- Para NF-e modelo 55, o bloco visual é CONVENÇÃO UNIVERSAL DE MERCADO (TOTVS, SAP, SmartGo, eMissor), não mandato literal. Spec deixa isso explícito.

ARTEFATOS
- proposal.md (5.9 KB): motivação + capability danfe-payment-block + impacto
- design.md (14 KB): 6 decisões ancoradas no código + open questions
- specs/danfe-payment-block/spec.md (8.2 KB): 8 requirements + 18 cenários BDD
- tasks.md (8.3 KB): 13 grupos (32 itens) cobrindo schema, viewmodel, producer, helper, renderer, fluxo, testes, fixtures, validação visual, docs, PR, archive

`openspec validate` OK.

Nenhuma mudança de código ainda — implementação virá via /opsx:apply no próximo commit.

Fixes #39



* feat(danfe): adiciona bloco FORMA DE PAGAMENTO (#39)

Adiciona o bloco "Forma de Pagamento" na DANFE de NF-e modelo 55, lendo o grupo <pag><detPag> do XML. Demanda do cliente Revenda Mais (invoice 9175b02ac0cf4ed898025c4bad09e2fe), umbrella #37.

MUDANÇAS

Schema (DanfeSharp/Esquemas/ProcNFe.cs)
- detPag ganha campo xPag (YA03 — descrição do pagamento).

ViewModel (DanfeSharp/Modelo/PagamentoViewModel.cs)
- DetalheViewModel ganha propriedade Descricao (mapeada de xPag).

Producer (DanfeSharp/Modelo/DanfeViewModelCreator.cs)
- Producer existente para <pag> em CreateFromProcNFCe ganha população de Descricao (xPag → Descricao com normalização "" → null).
- BUG RAIZ ADICIONAL: a população do grupo <pag> estava SÓ em CreateFromProcNFCe (NFC-e modelo 65) — faltava em CreateFromProcNFe (NF-e modelo 55, escopo desta change). Adicionado o foreach no CreateFromProcNFe antes do return — sem essa correção o renderer nunca dispararia para NF-e.

Helper (DanfeSharp/Modelo/FormaPagamentoExtensions.cs — novo)
- GetDescricao(this FormaPagamento) lê [DescriptionAttribute] via reflexão. Retorna string.Empty para enum value inválido (defensivo).

Renderer (DanfeSharp/Blocos/BlocoFormaPagamento.cs — novo)
- Herda BlocoBase. Cabecalho "Forma de Pagamento". Itera sobre Pagamento[].DetalhePagamento via SelectMany e cria uma LinhaCampos por detalhe com FORMA PAGAMENTO (Descricao ?? GetDescricao) + VALOR (ComCampoNumerico, sem prefixo R$ — convenção do BlocoCalculoImposto).
- Auto-omissão: early return quando detalhes == null/empty.

Sequência (DanfeSharp/Danfe.cs)
- AdicionarBloco<BlocoFormaPagamento>() inserido entre BlocoCalculoImposto e BlocoTransportador.
- Condicionado a Pagamento ser não-vazio (defense in depth).

TESTES (DanfeSharp.Test/FormaPagamentoTests.cs — novo)
- 14 testes em FormaPagamentoTests: helper para Dinheiro/CartaoCredito/ CartaoDebito/Outro/PIX/inválido, schema parsing com/sem <xPag>, ViewModel propertes, regra Descricao-prevalece-sobre-enum.
- 2 testes de integração em IntegracaoPagamentoNFe: NF-e v4 popula model.Pagamento (regressão do bug raiz §4.2); NF-e v3.10 sem <pag> não quebra e mantém Pagamento vazio.
- Aliases FormaPagamentoVm/FormaPagamentoSchema para desambiguar os 2 enums coexistentes (Modelo/Enums.cs e Esquemas/ProcNFe.cs).
- DanfeSharp.Test.csproj: <Reference Include="System.Xml" /> para acessar XmlSerializer nos testes de schema.

dotnet vstest:
- FormaPagamentoTests + IntegracaoPagamentoNFe: 16/16 verde (748 ms)
- DanfeXmlTests: 5/5 verde (zero regressão)
- PDF re-renderizado do v4_ComLocalEntrega.xml exibe o bloco no local esperado (texto extraído: "FORMA DE PAGAMENTO ... VALOR ... Outros ... 3.977,00").

HOTFIX TANGENCIAL (pré-existente em origin/main)
- FabricaFake.cs:51 cast (decimal?)v para vFCPUFDest
- DanfeTest.cs:63 DanfeCCC → DanfeCartaCorrecao
- Mesmas correções aplicadas na PR #41 (#38); necessárias para o projeto de teste compilar enquanto a #41 não merge na main.

OpenSpec change: openspec/changes/add-danfe-payment-block/ Spec validated: `openspec validate` OK.
38 tasks; tasks externas/manuais (§1, §10, §12, §13) seguem pendentes do lado humano (cliente + reviewer + post-merge archive).

Fixes #39



* refactor(danfe): layout horizontal dos campos da Duplicata (FATURA / DUPLICATA)

Reportado pelo cliente Revenda Mais durante revisão do PR #42: o quadro "FATURA / DUPLICATA" exibia Número / Vencimento / Valor empilhados verticalmente dentro de cada célula, ocupando 3× mais altura que o necessário. Refatora para layout horizontal, alinhando com o padrão visual do BlocoCalculoImposto e demais blocos com campos labelados.

Mudanças

- DanfeSharp/Elementos/Duplicata.cs: o Draw passa a dividir o bounding rect em 3 colunas iguais e desenhar cada par (label no topo + valor abaixo) lado a lado em vez de empilhar com CutTop. Height reduzida de 3*linha → 2*linha (label + valor).

- DanfeSharp/Blocos/BlocoDuplicataFatura.cs: numeroElementosLinha reduzido de 6→3 (retrato) e 7→4 (paisagem) para acomodar a largura necessária por célula no novo layout. Sem essa redução, os valores ("11/10/2018", "R$ 3.977,00") seriam cortados.

Validação visual

- v4_ComLocalEntrega.pdf re-renderizado. Texto extraído por pdftotext:
    Número                Vencimento:          Valor:
    001                   11/10/2018           R$ 3.977,00
  (em uma única linha, 3 colunas legíveis)

- dotnet vstest DanfeXmlTests: 5/5 aprovados, zero regressão.

Fora do escopo original do PR #42 (que cobre o bloco FORMA DE PAGAMENTO). Aplicado como hotfix de polish a pedido do criador da PR, conforme feedback durante revisão visual da DANFE rendererizada.

Base normativa: o MOC 7.0 Anexo II §3.1.6 ("Quadro Fatura/Duplicatas") não prescreve layout específico para os campos internos da duplicata — "Poderá conter linhas divisórias internas separando as informações." Layout escolhido alinha com a convenção dos demais blocos do DanfeSharp.

Refs #39


* test(danfe): fixture v4_RevendaMaisDemo para visualizar ambos os ajustes

XML sintético derivado de v4_ComLocalEntrega.xml mas com cobr/pag expandidos para exercitar todos os caminhos novos:

FATURA / DUPLICATA (validação do refactor 371ed39)
- 6 duplicatas mensais R$ 662,83 cada (sum 3.977,00 igual ao vLiq da fat). Demonstra o novo layout horizontal de campos + paginação em 2 linhas de 3 duplicatas (numeroElementosLinha=3 em retrato).

FORMA DE PAGAMENTO (validação da feature aaf6e9f)
- 3 <detPag> variados: • tPag=17 (PIX, NT 2020.001) — R$ 1.500,00 → renderiza "Pagamento Instantâneo (PIX)" via fallback do enum • tPag=03 (Cartão de Crédito) + grupo <card> — R$ 1.000,00 → renderiza "Cartão de Crédito" via fallback do enum • tPag=99 (Outros) + <xPag>VALE TROCO</xPag> — R$ 1.477,00 → renderiza "VALE TROCO" (xPag prevalecendo sobre "Outros", regra da spec danfe-payment-block)

Soma dos detPag = 3.977,00 = soma das duplicatas = vNF (consistente).

Wiring
- v4_RevendaMaisDemo.xml em DanfeSharp.Test/Xml/NFe/v4.00/
- <Content Include> + CopyToOutputDirectory em DanfeSharp.Test.csproj
- DanfeXmlTests.v4_RevendaMaisDemo() chama TestXml(...) que gera Output/DeXml/v4_RevendaMaisDemo.pdf

Validação
- dotnet vstest da suite completa (DanfeXmlTests + FormaPagamentoTests
  + IntegracaoPagamentoNFe) → 22/22 verde.
- Texto extraído do PDF confirma: FATURA / DUPLICATA: 6 duplicatas em 2 linhas, layout horizontal. FORMA DE PAGAMENTO: 3 linhas com FormaPagamento + Valor distintos.

Refs #39


* test(fixture): adiciona <infAdProd> em 2 produtos do demo

Para visualizar como a tag <infAdProd> (informações adicionais do produto, YA02 do MOC) é renderizada na DANFE:

- Item #1 (SOFTWARE A): <infAdProd>Licença digital · Não-reembolsável
  · S/N: ABC123-VERSAO-3.0</infAdProd>
- Item #2 (SOFTWARE B): <infAdProd>Garantia: 12 meses contra defeitos
  de fabricação · Suporte: 0800-XXX-YYYY</infAdProd>

A informação aparece logo abaixo do nome do produto, dentro da mesma célula da coluna "DESCRIÇÃO DO PRODUTO / SERVIÇO" (concatenada via ProdutoViewModel.DescricaoCompleta com separador \r\n). Conformidade com MOC 7.0 Anexo II §3.1.7 (pg 10): "As informações adicionais de produto deverão constar impressas no DANFE logo abaixo do item ao qual se referirem."

Validação: dotnet vstest v4_RevendaMaisDemo → aprovado; texto extraído por pdftotext confirma render correto com line wrap automático em strings longas.

Refs #39


* style(danfe): rename QUANTI.→QUANT. e diminui coluna para favorecer DESCRIÇÃO

Pedido durante revisão visual da PR #42:
- Renomear o cabeçalho da coluna Quantidade de "QUANTI." para "QUANT."
- Diminuir a largura da coluna (sobrava espaço pra abreviação mais curta)
- Devolver o espaço ganho à coluna DESCRIÇÃO DO PRODUTO / SERVIÇO (que é flex, width=0 — absorve automaticamente)

Mudanças em DanfeSharp/Blocos/TabelaProdutosServicos.cs:
- Retrato:   6F   → 4F     (-2F devolvidos à descrição)
- Paisagem:  5.25F → 3.75F (-1.5F devolvidos à descrição)
- Label em ambos os modos: "QUANTI." → "QUANT."

Validação: dotnet vstest DanfeXmlTests → 6/6 verde, zero regressão. Texto extraído do PDF confirma cabeçalho "QUANT." e descrição mais larga.

Refs #39


* style(danfe): diminui coluna NCM/SH em favor da DESCRIÇÃO

Continuação do ajuste visual da PR #42:
- NCM/SH: o conteúdo é sempre 8 dígitos (49111090) — não precisa do espaço atual. Diminuir e devolver à coluna DESCRIÇÃO (flex).

Retrato:   5.6F  → 4.5F  (-1.1F devolvidos à descrição)
Paisagem:  5.5F  → 4.5F  (-1.0F devolvido à descrição)

Validação: dotnet vstest DanfeXmlTests → 6/6 verde.

Refs #39


* fix(danfe): ajusta largura da coluna NCM/SH (4.5F → 5F)

O commit anterior (c72ebab) reduziu NCM/SH para 4.5F, mas a coluna ficou apertada demais — o último dígito do NCM de 8 dígitos era truncado (49111090 virava 4911109). Aumenta para 5F (ainda ganha 0.6F vs original em retrato, 0.5F em paisagem) garantindo que NCMs de 8 dígitos rendereizem completos.

Refs #39


* style(danfe): ajuste fino paisagem QUANT. 3.75F → 4.00F

Pedido durante review da PR #42: dar +0.25F à coluna QUANT. em modo paisagem (que estava apertada visualmente). DESCRIÇÃO (flex, width=0) absorve o ajuste automaticamente cedendo 0.25F.

Refs #39


* test(danfe): adiciona test methods para paisagem (demo + light fixture)

Pedido durante review da PR #42: gerar exemplos completos em retrato e paisagem. Adiciona 2 test methods em DanfeXmlTests:

- v4_RevendaMaisDemo_Paisagem: força Orientacao=Paisagem na fixture rica. Atualmente FALHA com "Height is invalid" — overflow vertical porque a fixture tem 6 duplicatas + 3 detPag que não cabem em A4 paisagem (mais baixa que retrato). Documentado como bug pre-existente do layout engine (mesmo problema dos testes Paisagem*/FabricaFake que já falhavam em main).

- v4_ComLocalEntrega_Paisagem: força paisagem na fixture leve (1 duplicata + 1 detPag) — funciona. Demonstra que a renderização paisagem em si está OK; falha do demo é por excesso de conteúdo.

DanfeViewModelCreator.cs:411 ainda hardcoda Orientacao=Retrato (comentário sobre netcore2.0 bug). Esses tests forçam override após o load.

Refs #39


* fix(danfe): paginar quando blocos topo overflow vertical (em vez de crash)

Bug: Danfe.Gerar() lançava "InvalidOperationException: Height is invalid" quando os blocos topo (Emitente, Destinatário, Local Entrega/Retirada, Fatura, Cálculo, Forma de Pagamento, Transportador, Dados Adicionais) consumiam toda a altura disponível da página — situação comum em paisagem com NF-e ricas (caso típico do cliente Revenda Mais com 6 duplicatas + 3 detPag + bloco FORMA).

Root cause: o while loop em Gerar() já suportava paginação via TabelaProdutosServicos.CompletamenteDesenhada, mas faltava um guard para casos onde RetanguloCorpo.Height ≤ 0 — ele tentava desenhar mesmo assim e o DrawableBase.Draw lançava.

Fix: adiciona guard em Gerar() — quando RetanguloCorpo.Height ≤ 0, pula a página sem desenhar a tabela. A próxima iteração cria uma nova página onde apenas BlocoIdentificacaoEmitente é desenhado (único com VisivelSomentePrimeiraPagina=false), liberando espaço para a tabela.

Proteção contra loop infinito: se 2 páginas consecutivas têm Height ≤ 0, lança erro descritivo orientando reduzir blocos opcionais ou usar Retrato.

Validação:
- v4_RevendaMaisDemo_Paisagem (heavy: 6 duplicatas + 3 detPag) — antes lançava NPE, agora gera PDF com 2 páginas: pág 1 = blocos topo, pág 2 = identificação + tabela produtos.
- v4_ComLocalEntrega_Paisagem (light) — continua passando.
- Retrato continua passando para todas as fixtures.
- Falhas pre-existentes em FabricaFake-based Paisagem tests (PaisagemSemIcmsInterestadual etc.) não são afetadas — são causadas por bug independente (TextoReservadoFisco():355 NotImplementedException por TipoEmissao=0 default no fake).

Refs #39


* test(fixtures): adiciona 3 demos cobrindo cenários extremos + intermediário

Para visualizar a renderização da DANFE em variações de complexidade (pedido durante review da PR #42):

- v4_DanfeMinimo.xml — 1 item sem infAdProd, sem <cobr>, sem <pag>. Caso de NF-e mínima (ex.: doação, brinde) sem fatura/pagamento. PDF gerado: 5.8 KB, 1 página.

- v4_DanfeIntermediario.xml — 5 itens (3 com infAdProd: notebook, teclado, monitor; 2 sem: mouse, cabo), 2 duplicatas R$ 500 cada, 2 detPag (Cartão Crédito R$ 600 + PIX R$ 400). Total R$ 1000. PDF: 6.7 KB.

- v4_DanfeCompleto.xml — 20 itens (todos com infAdProd "Lote LT-N-2026 · Validade 12 meses · Origem: Brasil"), 6 duplicatas mensais R$ 333.34 cada, 3 detPag (PIX 800 + Cartão Crédito 700 + Outros R$ 500 com xPag="PROMOCIONAL BLACK FRIDAY"). Total R$ 2000. PDF: 11 KB, múltiplas páginas (paginação automática graças ao fix em Danfe.Gerar()).

Geração via script reproduzível (generate-fixtures.sh) com helpers para gen_item, gen_dup, gen_detpag, gen_header, gen_footer. Reexecutável: bash DanfeSharp.Test/Xml/NFe/v4.00/generate-fixtures.sh

Wiring
- Content + CopyToOutputDirectory em DanfeSharp.Test.csproj
- 3 test methods em DanfeXmlTests (v4_DanfeMinimo, v4_DanfeIntermediario, v4_DanfeCompleto) que chamam TestXml(...) para gerar PDFs em bin/Debug/Output/DeXml/

Validação
- dotnet vstest dos 3 → todos aprovados.
- Sanity checks via pdftotext confirmam contagens esperadas: EX1: 0 FATURA, 0 FORMA, 1 PROD-, 0 infAdProd EX2: 1 FATURA, 1 FORMA, 5 PROD- EX3: 1 FATURA, 1 FORMA, 20 PROD-, 20 "Lote" (infAdProd)

Refs #39


* test(fixtures): adiciona 3 demos em paisagem (Mínimo + Intermediário + Completo)

Mesmas fixtures do commit anterior, agora renderizadas em paisagem para visualização completa do layout em ambos os modos.

Adicionado helper RenderPaisagem(xmlPath, outName) que carrega o XML e força Orientacao = Paisagem antes de gerar (necessário porque DanfeViewModelCreator hardcoda Retrato — comentário sobre netcore2.0 em DanfeViewModelCreator.cs:411).

3 novos test methods:
- v4_DanfeMinimo_Paisagem
- v4_DanfeIntermediario_Paisagem
- v4_DanfeCompleto_Paisagem (20 itens em paisagem — paginação automática graças ao fix do bug "Height is invalid" aplicado anteriormente)

Todos os 3 passam. PDFs gerados em bin/Debug/Output/DeXml/ com sufixo _Paisagem.

Refs #39


* feat(danfe): marca d'água "DOCUMENTO CANCELADO" para NF-e cancelada (#40)

Tema 3 do umbrella Revenda Mais (issue #37). Renderiza marca d'água "DOCUMENTO CANCELADO" centralizada em todas as páginas da DANFE quando a NF-e está cancelada.

ARQUITETURA — primeiro detectar via flag, depois cStat=101 como fallback

O cancelamento em NF-e modelo 55 é registrado via EVENTO SEPARADO (NFeProcEvento com tpEvento=110111), NÃO via mudança no <cStat> da NF-e original — o XML protocolo da nota mantém cStat=100 (Autorizado) mesmo após cancelamento autorizado. Quem sabe que a nota foi cancelada é o sistema do emissor consultando o histórico de eventos.

A PR #8 do @mateuszanini (2023, branch feature/aviso-cancelamento) tinha a renderização visualmente correta mas detectava via cStat=101 do XML protocolo — que na prática raramente é 101 para uma nota cancelada. Esta change reaproveita o método dele (DesenharAvisoCancelamento) mas usa flag explícita IsCancelled como mecanismo primário + cStat=101 como fallback OR (zero custo).

CÓDIGO

- DanfeSharp/Modelo/DanfeViewModel.cs:223 — nova propriedade IsCancelled (bool, default false) com XML doc explicando o motivo arquitetural (cancelamento via evento, não via cStat do XML).

- DanfeSharp/DanfePagina.cs:106 — novo método DesenharAvisoCancelamento espelhando DesenharAvisoHomologacao: TextStack centralizado no RetanguloCorpo, fonte 48pt regular, cor RGB(0.35, 0.35, 0.35), texto "DOCUMENTO CANCELADO". Padrão visual idêntico ao "SEM VALOR FISCAL" já existente — vamos da PR #8.

- DanfeSharp/Danfe.cs:CriarPagina — após DesenharAvisoHomologacao, adiciona "if (ViewModel.IsCancelled || ViewModel.CodigoStatusReposta == 101) p.DesenharAvisoCancelamento();". Sobreposição com aviso de homologação aceita (NF-e cancelada em homologação → ambos os avisos aparecem, comportamento correto).

TESTES (DanfeCanceladaTests.cs, 11 tests)

- Unit-level: IsCancelled default false, settable.
- Integration: render com IsCancelled=true, com cStat=101, com ambos, e regressão sem nenhum trigger.
- Demos: render dos 3 fixtures (Mínimo/Intermediário/Completo) + versões paisagem do Intermediário e Completo, todos com IsCancelled=true.
- pdftotext -raw confirma "DOCUMENTO CANCELADO" presente em todos os 5 PDFs cancelados (1x em página única, 2x em multi-página do Completo), e 0 ocorrências em DANFEs não-canceladas.
- DanfeXmlTests existentes: 14/14 verde (zero regressão).

BASE NORMATIVA

MOC 7.0 Anexo II §3.10.1 (Marca d'Água) autoriza literalmente: "O formulário poderá conter marca d'água desde que não prejudique a legibilidade dos dados impressos." NÃO obriga marca para nota cancelada, NÃO especifica texto/posição/opacidade. Texto e estilo são convenção universal de mercado (TOTVS/SAP/SmartGo/eMissor) alinhada ao "SEM VALOR FISCAL" do ambiente de homologação.

OpenSpec change: openspec/changes/add-cancelled-watermark/
- proposal.md, design.md (5 decisões), specs/danfe-cancelled-watermark/spec.md (5 requirements + 11 cenários), tasks.md (10 grupos).
- openspec validate ✓

Fixes #40
Refs PR #8 (@mateuszanini, 2023 — render mantida, gatilho substituído)



* refactor(danfe): bloco FORMA DE PAGAMENTO usa padrão visual de FATURA/DUPLICATA

Ajustes cosméticos pedidos durante review da PR #43:

1) Mover bloco FORMA DE PAGAMENTO para logo abaixo de FATURA/DUPLICATA
   (em Danfe.cs:CriarPagina). Ordem antiga:
     FATURA → CÁLCULO IMPOSTO → FORMA PAGAMENTO → TRANSPORTADOR
   Nova:
     FATURA → FORMA PAGAMENTO → CÁLCULO IMPOSTO → TRANSPORTADOR
   Agrupa os blocos de informação comercial (fatura + pagamento)
   adjacentes, separados dos fiscais (imposto + transportador).

2) Refatorar BlocoFormaPagamento para mesmo padrão visual do
   BlocoDuplicataFatura — cards lado a lado em FlexibleLine, cada
   um com 2 sub-colunas (FORMA PAGAMENTO + VALOR), label em cima
   e valor abaixo. Antes era 1 linha por detalhe via
   AdicionarLinhaCampos (estilo do BlocoCalculoImposto).

   Novo elemento DanfeSharp/Elementos/PagamentoDetalhe.cs espelhando
   Duplicata.cs:
   - 2 colunas iguais (FORMA PAGAMENTO + VALOR) com label em FonteA e valor em FonteB (mesmas fontes da Duplicata).
   - Descricao prevalece sobre [Description] do enum (regra da spec danfe-payment-block já existente).
   - Valor formatado com R$ via Formatador.FormatarMoeda (cast decimal→double).

   BlocoFormaPagamento usa FlexibleLine com N cards por linha:
   - Retrato: 2 (descrições podem ser longas, ex. "Pagamento Instantâneo (PIX)" = 28 chars; 4 cards/linha colidia)
   - Paisagem: 3

Validação visual em demo Completo (retrato, 3 detPag):
  Linha 1: PIX R$ 800,00 | Cartão de Crédito R$ 700,00
  Linha 2: VALE TROCO R$ 500,00

Em paisagem, os 3 detPag cabem na mesma linha.

Testes: 56/56 verde (zero regressão em ProdutoIcmsColumnTests, FormaPagamentoTests, IntegracaoPagamentoNFe, DanfeXmlTests, DanfeCanceladaTests). PDFs demo atualizados em
../danfe-payment-validation/{exemplos,exemplos-cancelada}/.

Refs #39


* style(danfe): Title Case nas labels de PagamentoDetalhe (espelha Duplicata)

Pedido durante review da PR #43: as labels internas do PagamentoDetalhe estavam em ALL UPPERCASE ("FORMA PAGAMENTO", "VALOR") enquanto as do Duplicata.cs estão em Title Case ("Número", "Vencimento:", "Valor:"). Alinhar para padrão único.

Mudança:
- "FORMA PAGAMENTO" → "Forma de Pagamento" (sem ':', como "Número")
- "VALOR" → "Valor:" (com ':', como "Vencimento:" e "Valor:" em Duplicata)

Refs #39


* chore(openspec): archive add-danfe-payment-block + add-cancelled-watermark

Promove 2 specs para openspec/specs/ ao final da sprint Revenda Mais:

- danfe-payment-block (#39) — bloco "Forma de Pagamento" da DANFE NF-e modelo 55 (schema <pag>/<detPag>/<xPag>, mapping tPag→descrição via [Description], prevalência de xPag, omissão graciosa, layout em cards estilo Duplicata).

- danfe-cancelled-watermark (#40) — marca d'água "DOCUMENTO CANCELADO" para NF-e cancelada (flag IsCancelled primária + cStat=101 fallback, fonte 48pt cinza centralizada em todas as páginas).

Purpose preenchido para os 2 specs (substituindo o placeholder TBD gerado pelo openspec archive), citando base normativa MOC 7.0 Anexo II + NT 2016.002 e reconhecendo que os formatos visuais são convenção universal de mercado (não mandato literal do MOC).

Changes movidas para openspec/changes/archive/:
- 2026-05-28-add-danfe-payment-block
- 2026-05-28-add-cancelled-watermark

(Já estavam arquivadas: 2026-05-28-fix-danfe-csosn-rendering, do tema 1 da sprint.)

Refs #37 (umbrella), #38, #39, #40


* fix: address PR #43 Copilot review (OCst setter + watermark assertions)

- ProdutoViewModel.OCst: restaura setter público como [Obsolete] com backing field _ocstLegacy, usado apenas quando Origem/Cst/Csosn estão todos vazios. Preserva ABI/source-compat para consumers que ainda atribuem OCst diretamente (uso anterior a Origem/Cst/Csosn).
- DanfeCanceladaTests: testes IsCancelledTrue, cStat101 e NaoCancelada agora extraem texto do PDF via TextExtractor do PDFClown (sem dependencia externa) e asseguram presenca/ausencia real da marca "DOCUMENTO CANCELADO"
  - antes eram smoke tests que passariam mesmo se a marca nunca fosse desenhada.



* fix(danfe): celulas vazias com borda em Fatura/Duplicata e Forma de Pagamento

Quando o numero de duplicatas/formas de pagamento nao fecha a linha de colunas (1 duplicata num bloco que cabe 3, p.ex.), as posicoes restantes ficavam como espaco em branco sem borda, truncando visualmente o quadro antes da margem direita. Substituido o ElementoVazio (Draw vazio, herdava DrawableBase) por CelulaVazia (herda ElementoBase, recebe Estilo e desenha apenas a borda via base.Draw -> StrokeRectangle), preenchendo o restante da linha com celulas com borda em retrato e paisagem.

Aplicado em BlocoDuplicataFatura e BlocoFormaPagamento; ElementoVazio mantido intacto (sem outros usuarios).



---------