### PR TITLE
feat(danfe): suporta NFC-e em contingência offline (tpEmis=9) (#46)

### DIFF
--- a/DanfeSharp/Blocos/NFC/BlocoInformacaoFiscal.cs
+++ b/DanfeSharp/Blocos/NFC/BlocoInformacaoFiscal.cs
@@ -1,4 +1,5 @@
-﻿using DanfeSharp.Modelo;
+using DanfeSharp.Esquemas.NFe;
+using DanfeSharp.Modelo;
 using org.pdfclown.documents.contents.composition;
 using System.Drawing;
 
@@ -8,22 +9,57 @@ namespace DanfeSharp.Blocos.NFC
     {
         public BlocoInformacaoFiscal(DanfeViewModel viewModel, Estilo estilo, PrimitiveComposer primitiveComposer, float y) : base(estilo)
         {
+            var currentY = y;
+
             if (viewModel.TipoAmbiente == 2)
             {
                 primitiveComposer.BeginLocalState();
                 primitiveComposer.SetFont(estilo.FonteCampoConteudoNegrito.FonteInterna, estilo.FonteTamanhoMinimo + 1);
-                primitiveComposer.ShowText("EMITIDA EM AMBIENTE DE HOMOLOGAÇÃO - SEM VALOR FISCAL", new PointF(132.5F, y + 10), XAlignmentEnum.Center, YAlignmentEnum.Middle, 0);
+                primitiveComposer.ShowText("EMITIDA EM AMBIENTE DE HOMOLOGAÇÃO - SEM VALOR FISCAL", new PointF(132.5F, currentY + 10), XAlignmentEnum.Center, YAlignmentEnum.Middle, 0);
 
-                Y_NFC = y + 20;
-                primitiveComposer.DrawLine(new PointF(15, Y_NFC), new PointF(265, Y_NFC));
+                currentY += 20;
+                primitiveComposer.DrawLine(new PointF(15, currentY), new PointF(265, currentY));
                 primitiveComposer.SetLineDash(new org.pdfclown.documents.contents.LineDash(new double[] { 3, 2 }));
                 primitiveComposer.Stroke();
                 primitiveComposer.End();
             }
-            else
+
+            // Contingência offline da NFC-e (tpEmis=9): a DANFE NFC-e DEVE indicar visivelmente que foi
+            // emitida em contingência e está pendente de autorização, exibindo a data/hora de entrada em
+            // contingência (dhCont) e a justificativa (xJust). Manual de Especificações Técnicas do DANFE
+            // NFC-e. Os dados já vêm no view model (ContingenciaDataHora/ContingenciaJustificativa).
+            if (viewModel.TipoEmissao == FormaEmissao.ContingenciaOffLineNFCe)
             {
-                Y_NFC = y;
+                primitiveComposer.BeginLocalState();
+
+                primitiveComposer.SetFont(estilo.FonteCampoConteudoNegrito.FonteInterna, estilo.FonteTamanhoMinimo + 1);
+                primitiveComposer.ShowText("EMITIDA EM CONTINGÊNCIA", new PointF(132.5F, currentY + 10), XAlignmentEnum.Center, YAlignmentEnum.Middle, 0);
+                currentY += 18;
+
+                primitiveComposer.SetFont(estilo.FonteCampoConteudo.FonteInterna, estilo.FonteTamanhoMinimo);
+                primitiveComposer.ShowText("Pendente de autorização da SEFAZ", new PointF(132.5F, currentY + 8), XAlignmentEnum.Center, YAlignmentEnum.Middle, 0);
+                currentY += 12;
+
+                if (viewModel.ContingenciaDataHora.HasValue)
+                {
+                    primitiveComposer.ShowText($"Entrada em contingência: {viewModel.ContingenciaDataHora.Value:dd/MM/yyyy HH:mm:ss}", new PointF(132.5F, currentY + 8), XAlignmentEnum.Center, YAlignmentEnum.Middle, 0);
+                    currentY += 12;
+                }
+
+                if (!string.IsNullOrWhiteSpace(viewModel.ContingenciaJustificativa))
+                {
+                    primitiveComposer.ShowText($"Justificativa: {viewModel.ContingenciaJustificativa}", new PointF(132.5F, currentY + 8), XAlignmentEnum.Center, YAlignmentEnum.Middle, 0);
+                    currentY += 12;
+                }
+
+                currentY += 8;
+                primitiveComposer.DrawLine(new PointF(15, currentY), new PointF(265, currentY));
+                primitiveComposer.SetLineDash(new org.pdfclown.documents.contents.LineDash(new double[] { 3, 2 }));
+                primitiveComposer.Stroke();
+                primitiveComposer.End();
             }
+
+            Y_NFC = currentY;
         }
     }
 }

--- a/DanfeSharp/Modelo/DanfeViewModel.cs
+++ b/DanfeSharp/Modelo/DanfeViewModel.cs
@@ -368,6 +368,7 @@ namespace DanfeSharp.Modelo
                 FormaEmissao.ContingenciaSVCAN => "SVC-AN",
                 FormaEmissao.ContingenciaSVCRS => "SVC-RS",
                 FormaEmissao.ContingenciaSCAN => "SCAN",
+                FormaEmissao.ContingenciaOffLineNFCe => "OFF-LINE NFC-e",
                 _ => throw new NotImplementedException()
             };
 

--- a/DanfeSharp/Modelo/DanfeViewModelCreator.cs
+++ b/DanfeSharp/Modelo/DanfeViewModelCreator.cs
@@ -266,7 +266,7 @@ namespace DanfeSharp.Modelo
                 throw new Exception("Modelo da nota difere de 65");
             }
 
-            if (ide.tpEmis != FormaEmissao.Normal && ide.tpEmis != FormaEmissao.ContingenciaDPEC && ide.tpEmis != FormaEmissao.ContingenciaFSDA && ide.tpEmis != FormaEmissao.ContingenciaSVCAN && ide.tpEmis != FormaEmissao.ContingenciaSVCRS)
+            if (ide.tpEmis != FormaEmissao.Normal && ide.tpEmis != FormaEmissao.ContingenciaDPEC && ide.tpEmis != FormaEmissao.ContingenciaFSDA && ide.tpEmis != FormaEmissao.ContingenciaSVCAN && ide.tpEmis != FormaEmissao.ContingenciaSVCRS && ide.tpEmis != FormaEmissao.ContingenciaOffLineNFCe)
             {
                 throw new Exception("Somente o tpEmis==1 está implementado.");
             }


### PR DESCRIPTION
* feat(danfe): suporta NFC-e em contingência offline (tpEmis=9) no DanfeViewModelCreator

CreateFromProcNFCe rejeitava tpEmis fora de {Normal, DPEC, FSDA, SVCAN, SVCRS} com 'Somente o tpEmis==1 está implementado.' — incluindo a Contingência Offline da NFC-e (tpEmis=9, FormaEmissao.ContingenciaOffLineNFCe). Libera o 9 no guard; o restante do método lê os campos do XML genericamente, então a DANFE offline é gerada normalmente.

Necessário para o fluxo de emissão offline de NFC-e do dfetech-product-invoice-api (OpenSpec speed-up-nfce-emission-with-offline-contingency, Fase 3 / parte B).



* feat(danfe): renderiza a contingência offline no cupom NFC-e (tpEmis=9)

O commit anterior do #46 apenas removeu o throw que bloqueava tpEmis=9 — o cupom passava a ser gerado, mas SEM indicar a contingência. Os dados (dhCont/xJust) já chegavam ao DanfeViewModel (ContingenciaDataHora/ContingenciaJustificativa), mas nenhum bloco do layout NFC-e os renderizava (só o TextoReservadoFisco da NF-e A4, que nem é usado no cupom).

- BlocoInformacaoFiscal (NFC-e): quando TipoEmissao == ContingenciaOffLineNFCe, imprime "EMITIDA EM CONTINGÊNCIA" + "Pendente de autorização da SEFAZ" + a data/hora de entrada em contingência (dhCont) + a justificativa (xJust), com separador, avançando o Y do layout. Coexiste com o aviso de homologação.
- TextoReservadoFisco (NF-e A4): adiciona o case ContingenciaOffLineNFCe ao switch (antes caía em NotImplementedException) — defensivo, já que tpEmis=9 agora é valor suportado.

Build do DanfeSharp verde.



---------